### PR TITLE
Dockerize Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,9 @@ dump.rdb
 
 # rbenv
 .ruby-version
+
+# vim Swap Files
+*.swp
+
+# Sqlite3 Database Files
+*.sqlite3

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,5 @@ RUN gem install bundler && bundle install
 COPY . /syncing-server
 
 # Migrate the DB and start development server
-# RUN rails db:migrate
-# CMD ["rails", "server", "-b", "0.0.0.0"]
+RUN rails db:migrate
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ruby:2.6.5-slim-stretch
+MAINTAINER Andy Duss <github@mindovermiles262>
+
+ENV RAILS_ENV=development
+
+# Update System
+RUN apt-get update && \
+  apt-get upgrade -y && \
+  apt-get install -y git build-essential libsqlite3-dev libmariadb-dev vim
+
+# Copy and install Gems
+COPY ./Gemfile      /syncing-server/Gemfile
+COPY ./Gemfile.lock /syncing-server/Gemfile.lock
+WORKDIR /syncing-server
+RUN gem install bundler && bundle install
+
+# Copy the remaining files
+COPY . /syncing-server
+
+# Migrate the DB and start development server
+# RUN rails db:migrate
+# CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.6.5-slim-stretch
 MAINTAINER Andy Duss <github@mindovermiles262>
 
-ENV RAILS_ENV=development
+ENV RAILS_ENV=docker_development
 
 # Update System
 RUN apt-get update && \

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'rotp'
 # Used for 'respond_to' feature
 gem 'responders', '~> 2.0'
 
-group :development, :test do
+group :development, :test, :docker_development do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
   gem 'spring'
@@ -28,7 +28,9 @@ group :development, :test do
   # Used by Mailatcher
   gem 'sinatra', github: 'sinatra'
   gem 'mailcatcher'
+end
 
+group :development, :test do
   # Deployment tools
   gem 'capistrano'
   gem 'capistrano-bundler'
@@ -37,4 +39,8 @@ group :development, :test do
   gem 'capistrano-rvm'
   gem 'capistrano-sidekiq'
   gem 'capistrano-shoryuken', github: 'mobitar/capistrano-shoryuken'
+end
+
+group :docker_development do
+  gem 'sqlite3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,6 +300,7 @@ DEPENDENCIES
   shoryuken
   sinatra!
   spring
+  sqlite3
   whenever
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -41,33 +41,27 @@ You can run your own Standard Notes server and use it with any Standard Notes ap
 
 ### Environment variables
 
-**SECRET_KEY_BASE**
+See `env.sample`
 
-Rails secret key used only in production environment
+### Docker Setup
 
-**RAILS_ENV**
+Docker is the quick and easy way to try out Standard Notes. With two commands you'll be up and running.
 
-Rails environment, set it to `production` on production server.
+#### Standalone Instance
 
-**DB_HOST**
+The `Dockerfile` is enough to get you up and running. Once Docker is installed on your system simply run the following commands to get up and running in Development Mode.
 
-Database host.
+```
+$ docker build -t syncing-server .
+$ docker run -d \
+  -p 3000:3000 \
+  --name my-syncing-server \
+  syncing-server
+```
 
-**DB_PORT**
+You can then access the server via the Desktop application by setting the Sync Server Domain (Under Advanced Options) to `http://localhost:3000`
 
-Database port. 3306 is standard.
-
-**DB_DATABASE**
-
-Database name.
-
-**DB_USERNAME**
-
-Database username.
-
-**DB_PASSWORD**
-
-Database password.
+Note: This standalone setup is designed for Development use only. Please use the `docker-compose` method (coming soon) for production instances.
 
 ## License
 

--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -109,7 +109,9 @@ class Api::AuthController < Api::ApiController
       user = result[:user]
       user.updated_with_user_agent = request.user_agent
       user.save
-      RegistrationJob.perform_later(user.email, user.created_at.to_s)
+      if ENV['AWS_REGION']
+        RegistrationJob.perform_later(user.email, user.created_at.to_s)
+      end
       render :json => result
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,9 +10,10 @@ module StandardNotes
 
     Shoryuken.logger.level = Logger::FATAL
     config.active_job.queue_adapter = :shoryuken
-    config.action_mailer.deliver_later_queue_name = ENV["SQS_QUEUE"] ? ENV["SQS_QUEUE"] : (Rails.env.production? ? 'sn_main' : 'dev_queue')
+    config.action_mailer.deliver_later_queue_name = ENV['SQS_QUEUE'] || 'dev_queue'
 
     raven_dsn = ENV["RAVEN_DSN"]
+    byebug
     if raven_dsn
       Raven.configure do |config|
         config.dsn = raven_dsn

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,6 @@ module StandardNotes
     config.action_mailer.deliver_later_queue_name = ENV['SQS_QUEUE'] || 'dev_queue'
 
     raven_dsn = ENV["RAVEN_DSN"]
-    byebug
     if raven_dsn
       Raven.configure do |config|
         config.dsn = raven_dsn

--- a/config/database.yml
+++ b/config/database.yml
@@ -39,3 +39,9 @@ staging:
 
 production:
   <<: *default
+
+docker_development:
+  adapter: sqlite3
+  pool: 5
+  timeout: 5000
+  database: db/docker.sqlite3

--- a/config/environments/docker_development.rb
+++ b/config/environments/docker_development.rb
@@ -2,7 +2,6 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   config.middleware.delete Rack::Lock
-
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # In the development environment your application's code is reloaded on
@@ -12,10 +11,8 @@ Rails.application.configure do
   config.reload_classes_only_on_change = true
 
   config.logger = ActiveSupport::Logger.new(config.paths['log'].first, 1, 1 * 1024 * 1024)
-
-  require 'custom_log_formatter'
-  config.log_formatter = CustomLogFormatter.new
-  config.logger.formatter = config.log_formatter
+  config.logger = Logger.new(STDOUT)
+  config.logger.level = Logger::INFO
 
   # Do not eager load code on boot.
   config.eager_load = false

--- a/config/environments/docker_development.rb
+++ b/config/environments/docker_development.rb
@@ -1,0 +1,64 @@
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  config.middleware.delete Rack::Lock
+
+  # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # In the development environment your application's code is reloaded on
+  # every request. This slows down response time but is perfect for development
+  # since you don't have to restart the web server when you make code changes.
+  config.cache_classes = false
+  config.reload_classes_only_on_change = true
+
+  config.logger = ActiveSupport::Logger.new(config.paths['log'].first, 1, 1 * 1024 * 1024)
+
+  require 'custom_log_formatter'
+  config.log_formatter = CustomLogFormatter.new
+  config.logger.formatter = config.log_formatter
+
+  # Do not eager load code on boot.
+  config.eager_load = false
+
+  # Show full error reports and disable caching.
+  config.consider_all_requests_local       = true
+  config.action_controller.perform_caching = false
+
+  # Don't care if the mailer can't send.
+  config.action_mailer.raise_delivery_errors = false
+
+  # config.public_file_server.enabled = true
+
+  # Print deprecation notices to the Rails logger.
+  config.active_support.deprecation = :log
+
+  # Raise an error on page load if there are pending migrations.
+  # config.active_record.migration_error = :page_load
+
+  # Debug mode disables concatenation and preprocessing of assets.
+  # This option may cause significant delays in view rendering with a large
+  # number of complex assets.
+  config.assets.debug = true
+
+  # Asset digests allow you to set far-future HTTP expiration dates on all assets,
+  # yet still be able to expire them through the digest params.
+  config.assets.digest = true
+
+  # Adds additional error checking when serving assets at runtime.
+  # Checks for improperly declared sprockets dependencies.
+  # Raises helpful error messages.
+  config.assets.raise_runtime_errors = true
+
+  # config.active_job.queue_adapter = :inline
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+
+  config.action_mailer.smtp_settings = {
+    :address => ENV['SMTP_HOST'],
+    :port => ENV['SMTP_PORT'],
+  }
+
+  # Raises error for missing translations
+  # config.action_view.raise_on_missing_translations = true
+  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,9 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Overwrite queue name from application.rb
+  config.action_mailer.deliver_later_queue_name = ENV['SQS_QUEUE'] || 'sn_main'
+
   # Code is not reloaded between requests.
   config.cache_classes = true
   MAX_LOG_MEGABYTES = 50

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -19,6 +19,9 @@ test:
 staging:
   secret_key_base: fd5255d5cc6a90944a292df8041cd125e20f28fd62cabf092133ce569457e7399e90294dc0413a43ed7e15f8414593632ff6b41b34d6361fab2069f6351958f6
 
+docker_development:
+  secret_key_base: a70c598973e8143a507810187df9065ea5438a019c0d2792036c8bb10cf72b9ec4645b7c794d5faab579d1f238acff6ef8bbcffe7e2149ecd7ddda606e0b7a40
+
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:

--- a/env.sample
+++ b/env.sample
@@ -1,0 +1,20 @@
+# Sample ENV setup Variables
+# Copy this file and update as needed.
+#
+#   $ cp env.sample .env
+#
+# Do not include this new file in source control
+#
+
+# Rails Settings
+SECRET_KEY_BASE: changeme123
+RAILS_ENV: development
+#SQS_QUEUE: somequeue
+#AWS_REGION: us-west1
+
+# Database Settings
+DB_HOST: 127.0.0.1
+DB_PORT: 3306
+DB_DATABASE: database_name
+DB_USERNAME: db_user
+DB_PASSWORD: changeme123


### PR DESCRIPTION
This PR creates a new `docker_development` rails environment that uses Sqlite3 as a standalone database.

The container can be stood up and running within minutes given the instructions added to the README.

Some conditions inside `config/application.rb` needed to be changed to check if ENV vars were available. It appears you use `AWS_REGION` and `SQS_QUEUE` environment variables but are not managing a list of env vars inside source control. I've moved all the settings to an `env.sample` file that will keep track of all the vars that need tracking.  Instructions on how to use the sample file are included, but you'll just need to copy the file to `.env` and rails will pick it up when booting up.

Please let me know if you have any questions or concerns

Thanks