### PR TITLE
Remove sqlite3 usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV RAILS_ENV=docker_development
 # Update System
 RUN apt-get update && \
   apt-get upgrade -y && \
-  apt-get install -y git build-essential libsqlite3-dev libmariadb-dev vim
+  apt-get install -y git build-essential libmariadb-dev vim
 
 # Copy and install Gems
 COPY ./Gemfile      /syncing-server/Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,3 @@ group :development, :test do
   gem 'capistrano-sidekiq'
   gem 'capistrano-shoryuken', github: 'mobitar/capistrano-shoryuken'
 end
-
-group :docker_development do
-  gem 'sqlite3'
-end

--- a/Gemfile
+++ b/Gemfile
@@ -24,10 +24,6 @@ group :development, :test, :docker_development do
   gem 'puma'
   gem 'listen'
   gem 'rspec-rails'
-
-  # Used by Mailatcher
-  gem 'sinatra', github: 'sinatra'
-  gem 'mailcatcher'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,18 +5,6 @@ GIT
     capistrano-shoryuken (0.1.5)
       capistrano
 
-GIT
-  remote: https://github.com/sinatra/sinatra.git
-  revision: 6ee7fc1a42e0e930eb603b9a4b67a4ff7406bfe0
-  specs:
-    rack-protection (2.0.7)
-      rack
-    sinatra (2.0.7)
-      mustermann (~> 1.0)
-      rack (~> 2.0)
-      rack-protection (= 2.0.7)
-      tilt (~> 2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -99,7 +87,6 @@ GEM
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
     crass (1.0.5)
-    daemons (1.3.1)
     diff-lcs (1.3)
     dotenv (2.7.5)
     dotenv-rails (2.7.5)
@@ -107,7 +94,6 @@ GEM
       railties (>= 3.2, < 6.1)
     erubi (1.9.0)
     erubis (2.7.0)
-    eventmachine (1.2.7)
     faraday (0.17.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
@@ -130,7 +116,6 @@ GEM
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
-    json (2.2.0)
     jwt (2.2.1)
     listen (3.2.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -140,22 +125,11 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    mailcatcher (0.2.4)
-      eventmachine
-      haml
-      i18n
-      json
-      mail
-      sinatra
-      skinny (>= 0.1.2)
-      sqlite3-ruby
-      thin
     method_source (0.9.2)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.12.2)
     multipart-post (2.1.1)
-    mustermann (1.0.3)
     mysql2 (0.4.10)
     net-scp (2.0.0)
       net-ssh (>= 2.6.5, < 6.0.0)
@@ -168,6 +142,8 @@ GEM
       nio4r (~> 2.0)
     rack (2.0.7)
     rack-cors (1.0.3)
+    rack-protection (2.0.8.1)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.1.7)
@@ -235,9 +211,6 @@ GEM
       rack (>= 1.5.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 5)
-    skinny (0.2.2)
-      eventmachine (~> 1.0)
-      thin
     spring (2.0.2)
       activesupport (>= 4.2)
     sprockets (3.7.2)
@@ -247,17 +220,10 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.1)
-    sqlite3-ruby (1.3.3)
-      sqlite3 (>= 1.3.3)
     sshkit (1.20.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     temple (0.8.2)
-    thin (1.7.2)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0, >= 1.0.4)
-      rack (>= 1, < 3)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -287,7 +253,6 @@ DEPENDENCIES
   haml-rails
   jwt
   listen
-  mailcatcher
   mysql2 (>= 0.3.13, < 0.5)
   puma
   rack-cors
@@ -298,10 +263,8 @@ DEPENDENCIES
   secure_headers
   sentry-raven
   shoryuken
-  sinatra!
   spring
-  sqlite3
   whenever
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/config/database.yml
+++ b/config/database.yml
@@ -41,7 +41,4 @@ production:
   <<: *default
 
 docker_development:
-  adapter: sqlite3
-  pool: 5
-  timeout: 5000
-  database: db/docker.sqlite3
+  <<: *default


### PR DESCRIPTION
For #16 

As explained on [this](https://devcenter.heroku.com/articles/sqlite3) article, SQLite is not intended as a production grade database. Instead, Heroku recommends using a production grade database like Postgres, although we are sticking to MySQL.

