### PR TITLE
Add instructions to disable registrations using docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,26 @@ To stop the server, `cd` into this directory again and run `docker-compose down`
 
 Your MySQL Data will be written to your local disk at `/var/lib/mysql` - Be sure to back this up in a production instance.
 
+### Disable new account registrations
+To disable the registration of new user accounts, follow these instructions.
+
+**Docker Compose**
+1. Edit the file `config/routes.rb`
+
+2. Comment out the following lines and save the file
+	```
+	post "auth" => "api/auth#register"
+	```
+	```
+	post "auth" => "auth#register"`
+	```
+3. Run `docker-compose down` top stop all containers
+
+4. Run `docker-compose build --no-cache app` to rebuild the app
+
+5. Run `docker-compose up` 
+		
+
 ### Heroku
 
 You can deploy your own Standard Notes server with one click on Heroku:


### PR DESCRIPTION
This PR will add instructions on how to disable the registration for new accounts using docker-compose based on https://github.com/standardfile/ruby-server/issues/74