### PR TITLE
Load secrets from .env file

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -11,19 +11,19 @@
 # if you're sharing your code publicly.
 
 development:
-  secret_key_base: e3336569c7fc35724ab2f19ca4024f70f20a372ffccf619064007593aa7e4ad0afafb88eb4c03620bdb10f3e975b0240a95c8cfc8b7664750208b9cf9b039f01
+  secret_key_base: <%= ENV["SECRET_KEY_BASE_DEV"] %>
 
 test:
-  secret_key_base: 7eedf23ca7967ab47b0a7e1c1f3bbf1f804f0d76ae7b27e8a37e9cbbffad95f099901f5b4821f391bcdeb104d2e0b1333cf56d485ad3ee41bc7fad2fbaf7ec3e
+  secret_key_base: <%= ENV["SECRET_KEY_BASE_TEST"] %>
 
 staging:
-  secret_key_base: fd5255d5cc6a90944a292df8041cd125e20f28fd62cabf092133ce569457e7399e90294dc0413a43ed7e15f8414593632ff6b41b34d6361fab2069f6351958f6
+  secret_key_base: <%= ENV["SECRET_KEY_BASE_STAGING"] %>
 
 docker_development:
-  secret_key_base: a70c598973e8143a507810187df9065ea5438a019c0d2792036c8bb10cf72b9ec4645b7c794d5faab579d1f238acff6ef8bbcffe7e2149ecd7ddda606e0b7a40
+  secret_key_base: <%= ENV["SECRET_KEY_BASE_DEV"] %>
 
 raspberry_pi:
-  secret_key_base: 4985e858992e690cecd56bd08611f5f1b6622c62c5fd65278da5dcaf3a8354830a7cfee53c020e79e825e759ab826c2c6b0d70eccb2f36e28282646933ff0c58
+  secret_key_base: <%= ENV["SECRET_KEY_BASE_DEV"] %>
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.

--- a/env.sample
+++ b/env.sample
@@ -8,7 +8,6 @@
 
 # Rails Settings
 EXPOSED_PORT=3000
-SECRET_KEY_BASE=changeme123
 RAILS_ENV=development
 #SQS_QUEUE=somequeue
 #AWS_REGION=us-west1
@@ -16,8 +15,17 @@ RAILS_ENV=development
 # Database Settings
 DB_PORT=3306
 DB_HOST=127.0.0.1
-
 DB_DATABASE=standard_notes_db
 DB_USERNAME=std_notes_user
-DB_PASSWORD=changeme123
-DB_ROOT_PASSWORD=changeme123
+DB_PASSWORD=changeme123 # Please change this!
+DB_ROOT_PASSWORD=changeme123 # Please change this!
+
+# Secrets
+# Use: bundle exec rake secret
+# To generate required secrets below
+#
+
+#SECRET_KEY_BASE=
+#SECRET_KEY_BASE_DEV=
+#SECRET_KEY_BASE_TEST=
+#SECRET_KEY_BASE_STAGING=


### PR DESCRIPTION
Secrets should be generated and defined by users explicitly in the `.env` file.