### PR TITLE
Changed Example env file

### DIFF
--- a/env.sample
+++ b/env.sample
@@ -17,12 +17,14 @@ DB_PORT=3306
 DB_HOST=127.0.0.1
 DB_DATABASE=standard_notes_db
 DB_USERNAME=std_notes_user
-DB_PASSWORD=changeme123 # Please change this!
-DB_ROOT_PASSWORD=changeme123 # Please change this!
+# Please change this!
+DB_PASSWORD=changeme123
+# Please change this!
+DB_ROOT_PASSWORD=changeme123
 
 # Secrets
 # Use: bundle exec rake secret
 # To generate required secrets below
 #
 
-#SECRET_KEY_BASE=
+SECRET_KEY_BASE=changeme123


### PR DESCRIPTION
Fixes #41 , and probably #27, #28 

I know the example env file specifically advises to use `bundle exec rake secret` to generate these secrets, but since no default is given, I thought it might help.