### PR TITLE
Automatically lowercase user emails on registration

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
 
   has_many :items, -> { order 'created_at desc' }, foreign_key: 'user_uuid'
 
+  before_create { email.downcase! }
+
   def serializable_hash(options = {})
     super(options.merge(only: ['email', 'uuid']))
   end
@@ -104,5 +106,9 @@ class User < ApplicationRecord
       item.content.bytesize
     end
     sorted.reverse.map { |item| { uuid: item.uuid, size: bytes_to_megabytes(item.content.bytesize) } }
+  end
+
+  def find_by_email(email)
+    user.where('lower(email) = ?', email.downcase).first
   end
 end

--- a/spec/controllers/api/auth_controller_spec.rb
+++ b/spec/controllers/api/auth_controller_spec.rb
@@ -213,6 +213,32 @@ RSpec.describe Api::AuthController, type: :controller do
         expect(parsed_response_body['token']).to_not be_nil
       end
     end
+
+    context 'when providing an email address that contains uppercased letters' do
+      it 'should register using the lowercased email address' do
+        new_user_email = 'NEW-User@SN-EMAIL.Org'
+        post :register, params: { email: new_user_email, password: '123456' }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
+        parsed_response_body = JSON.parse(response.body)
+
+        expect(parsed_response_body).to_not be_nil
+        expect(parsed_response_body['user']).to_not be_nil
+        expect(parsed_response_body['user']['email']).to eq(new_user_email.downcase)
+        expect(parsed_response_body['token']).to_not be_nil
+
+        post :register, params: { email: 'New-user@Sn-Email.Org', password: '123456' }
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
+        parsed_response_body = JSON.parse(response.body)
+
+        expect(parsed_response_body).to_not be_nil
+        expect(parsed_response_body['error']).to_not be_nil
+        expect(parsed_response_body['error']['message']).to eq('This email is already registered.')
+      end
+    end
   end
 
   describe 'POST auth/update' do


### PR DESCRIPTION
The `email` field is lower-cased when a new user registers. Likewise, when a login request is performed, the `email` field is lower-cased when looking it up on the database.