### PR TITLE
Fix Docker CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
 COPY . /syncing-server
 WORKDIR /syncing-server
 
-# On Raspberry Pi, we should use bcrypt 3.1.12 instead of 3.1.13 
+# On Raspberry Pi, we should use bcrypt 3.1.12 instead of 3.1.13
 # within the Gemfile.lock file
 RUN if [ "$optimize_for_raspberry_pi" = true ] ; then sed -i 's/bcrypt (3.1.13)/bcrypt (3.1.12)/g' Gemfile.lock; fi
 
@@ -19,4 +19,4 @@ RUN if [ "$optimize_for_raspberry_pi" = true ] ; then sed -i 's/bcrypt (3.1.13)/
 RUN gem install bundler && bundle install
 
 # Migrate the DB and start development server
-CMD "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"
+CMD bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0


### PR DESCRIPTION
When running CMD in quotes the PATH to the script is reset thus resulting in `bundler` not being present in the shell. When running the image the output from the container is:
```
/bin/sh: 1: bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0: not found
```

Removing the quotes fixes the issue