### PR TITLE
Add note revisions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.5
+        ruby-version: 2.6.5
     - name: Copy default configuration
       run: cp env.sample .env
     - name: Install dependencies

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -30,6 +30,8 @@ jobs:
       run: cp env.sample .env
     - name: Install dependencies
       run: bundle install
+    - name: Setup database
+      run: bundle exec rails db:create db:migrate
     - name: Run tests
       run: bundle exec rspec
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.5
+        ruby-version: 2.6.5
     - name: Copy default configuration
       run: cp env.sample .env
     - name: Install dependencies

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,5 +30,7 @@ jobs:
       run: cp env.sample .env
     - name: Install dependencies
       run: bundle install
+    - name: Setup database
+      run: bundle exec rails db:create db:migrate
     - name: Run tests
       run: bundle exec rspec

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.5
+        ruby-version: 2.6.5
     - name: Copy default configuration
       run: cp env.sample .env
     - name: Install dependencies

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -30,6 +30,8 @@ jobs:
       run: cp env.sample .env
     - name: Install dependencies
       run: bundle install
+    - name: Setup database
+      run: bundle exec rails db:create db:migrate
     - name: Run tests
       run: bundle exec rspec
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # OS & IDE
 .DS_Store
+.vscode
 
 # Ignore bundler config.
 /.bundle
@@ -48,3 +49,6 @@ dump.rdb
 
 # byebug history
 .byebug_history
+
+# MySQL container data
+data/

--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -90,7 +90,7 @@ class Api::ItemsController < Api::ApiController
   private
 
   def permitted_params
-    [:content_type, :content, :auth_hash, :enc_item_key, :items_key_id]
+    [:content_type, :content, :auth_hash, :enc_item_key, :items_key_id, :duplicate_of]
   end
 
   def sync_manager

--- a/app/controllers/api/revisions_controller.rb
+++ b/app/controllers/api/revisions_controller.rb
@@ -1,0 +1,13 @@
+class Api::RevisionsController < Api::ApiController
+  def show
+    revision = current_user.items.find(params[:item_id]).revisions.find(params[:id])
+
+    render json: revision
+  end
+
+  def index
+    item = current_user.items.where(uuid: params[:item_id]).first
+
+    render json: item.get_revision_history(User::REVISIONS_RETENTION_DAYS)
+  end
+end

--- a/app/controllers/api/revisions_controller.rb
+++ b/app/controllers/api/revisions_controller.rb
@@ -6,8 +6,8 @@ class Api::RevisionsController < Api::ApiController
   end
 
   def index
-    item = current_user.items.where(uuid: params[:item_id]).first
+    item = current_user.items.find(params[:item_id])
 
-    render json: item.get_revision_history(User::REVISIONS_RETENTION_DAYS)
+    render json: item&.get_revision_history(User::REVISIONS_RETENTION_DAYS)
   end
 end

--- a/app/controllers/api/revisions_controller.rb
+++ b/app/controllers/api/revisions_controller.rb
@@ -9,7 +9,7 @@ class Api::RevisionsController < Api::ApiController
     begin
       item = current_user.items.find(params[:item_id])
     rescue ActiveRecord::RecordNotFound
-      return render json: { error: 'Item not found' }, status: :not_found
+      return render json: { error: { message: 'Item not found' } }, status: :not_found
     end
 
     render json: item.revisions.where(created_at: User::REVISIONS_RETENTION_DAYS.days.ago..DateTime::Infinity.new)

--- a/app/controllers/api/revisions_controller.rb
+++ b/app/controllers/api/revisions_controller.rb
@@ -6,8 +6,12 @@ class Api::RevisionsController < Api::ApiController
   end
 
   def index
-    item = current_user.items.find(params[:item_id])
+    begin
+      item = current_user.items.find(params[:item_id])
+    rescue ActiveRecord::RecordNotFound
+      return render json: { error: 'Item not found' }, status: :not_found
+    end
 
-    render json: item&.get_revision_history(User::REVISIONS_RETENTION_DAYS)
+    render json: item.revisions.where(created_at: User::REVISIONS_RETENTION_DAYS.days.ago..DateTime::Infinity.new)
   end
 end

--- a/app/jobs/cleanup_revisions_job.rb
+++ b/app/jobs/cleanup_revisions_job.rb
@@ -9,7 +9,7 @@ class CleanupRevisionsJob < ApplicationJob
       .select('created_at')
       .order('created_at DESC')
       .group_by { |x| x.created_at.strftime('%Y-%m-%d') }
-      .take(30)
+      .take(days)
 
     days_to_process = []
     last_days_of_revisions.each do |day, _revisions|

--- a/app/jobs/cleanup_revisions_job.rb
+++ b/app/jobs/cleanup_revisions_job.rb
@@ -1,0 +1,36 @@
+class CleanupRevisionsJob < ApplicationJob
+  MAX_REVISIONS_PER_DAY = 30
+  MIN_REVISIONS_PER_DAY = 2
+
+  def perform(item_id, days)
+    item = Item.find(item_id)
+
+    days.times do |days_from_today|
+      allowed_revisions_count = [[days - days_from_today, MAX_REVISIONS_PER_DAY].min, MIN_REVISIONS_PER_DAY].max
+      cleanup_revisions_for_a_day(item, days_from_today, allowed_revisions_count)
+    end
+  end
+
+  def cleanup_revisions_for_a_day(item, days_from_today, allowed_revisions_count)
+    date = Time.now.utc.to_date - days_from_today
+    revisions_from_date_count = item.revisions.where(created_at: date.midnight..date.end_of_day).size
+
+    if revisions_from_date_count > allowed_revisions_count
+      revisions_from_date = item.revisions
+        .where(created_at: date.midnight..date.end_of_day)
+        .order(created_at: :desc)
+        .pluck(:uuid)
+
+      revisions_slice_size = (revisions_from_date.length.to_f / allowed_revisions_count).floor
+      revisions_to_keep = revisions_from_date
+        .each_slice(revisions_slice_size)
+        .map(&:last)
+        .last(allowed_revisions_count)
+
+      Revision
+        .where(created_at: date.midnight..date.end_of_day)
+        .where.not(uuid: revisions_to_keep)
+        .destroy_all
+    end
+  end
+end

--- a/app/jobs/duplicate_revisions_job.rb
+++ b/app/jobs/duplicate_revisions_job.rb
@@ -1,10 +1,19 @@
 class DuplicateRevisionsJob < ApplicationJob
   def perform(item_id)
     item = Item.find(item_id)
-    original_item_revisions = ItemRevision.where(item_uuid: item.duplicate_of).pluck(:revision_uuid)
 
-    original_item_revisions.each do |revision_uuid|
-      ItemRevision.create(item_uuid: item_id, revision_uuid: revision_uuid)
+    existing_original_item = Item
+      .where(uuid: item.duplicate_of, user_uuid: item.user_uuid)
+      .first
+
+    if existing_original_item
+      original_item_revisions = existing_original_item
+        .item_revisions
+        .pluck(:revision_uuid)
+
+      original_item_revisions.each do |revision_uuid|
+        ItemRevision.create(item_uuid: item_id, revision_uuid: revision_uuid)
+      end
     end
   end
 end

--- a/app/jobs/duplicate_revisions_job.rb
+++ b/app/jobs/duplicate_revisions_job.rb
@@ -1,0 +1,10 @@
+class DuplicateRevisionsJob < ApplicationJob
+  def perform(item_id)
+    item = Item.find(item_id)
+    original_item_revisions = ItemRevision.where(item_uuid: item.duplicate_of).pluck(:revision_uuid)
+
+    original_item_revisions.each do |revision_uuid|
+      ItemRevision.create(item_uuid: item_id, revision_uuid: revision_uuid)
+    end
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -68,7 +68,9 @@ class Item < ApplicationRecord
   private
 
   def cleanup_excessive_revisions(days = User::REVISIONS_RETENTION_DAYS)
-    CleanupRevisionsJob.perform_later(uuid, days)
+    if content_type == 'Note'
+      CleanupRevisionsJob.perform_later(uuid, days)
+    end
   end
 
   def persist_revision

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -105,7 +105,6 @@ class Item < ApplicationRecord
     revision = Revision.new
     revision.content = content
     revision.content_type = content_type
-    revision.user_uuid = user_uuid
     revision.enc_item_key = enc_item_key
     revision.auth_hash = auth_hash
     revision.save

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,7 +3,8 @@ class Item < ApplicationRecord
   has_many :item_revisions, foreign_key: 'item_uuid', dependent: :destroy
   has_many :revisions, -> { order 'revisions.created_at DESC' }, through: :item_revisions, dependent: :destroy
 
-  after_commit :persist_revision, :cleanup_excessive_revisions, :duplicate_revisions
+  after_commit :persist_revision, :cleanup_excessive_revisions
+  after_create :duplicate_revisions
 
   def serializable_hash(options = {})
     allowed_options = [

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -87,6 +87,7 @@ class Item < ApplicationRecord
       revision.content = content
       revision.content_type = content_type
       revision.enc_item_key = enc_item_key
+      revision.items_key_id = items_key_id
       revision.auth_hash = auth_hash
       revision.save
 

--- a/app/models/item_revision.rb
+++ b/app/models/item_revision.rb
@@ -1,0 +1,4 @@
+class ItemRevision < ApplicationRecord
+  belongs_to :item, foreign_key: 'item_uuid'
+  belongs_to :revision, foreign_key: 'revision_uuid'
+end

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -1,0 +1,4 @@
+class Revision < ApplicationRecord
+  has_many :item_revisions, foreign_key: 'revision_uuid'
+  has_many :items, through: :item_revisions
+end

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -1,4 +1,4 @@
 class Revision < ApplicationRecord
-  has_many :item_revisions, foreign_key: 'revision_uuid'
+  has_many :item_revisions, foreign_key: 'revision_uuid', dependent: :destroy
   has_many :items, through: :item_revisions
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,8 @@ class User < ApplicationRecord
 
   SESSIONS_PROTOCOL_VERSION = 4
 
+  REVISIONS_RETENTION_DAYS = 30
+
   def serializable_hash(options = {})
     super(options.merge(only: ['email', 'uuid']))
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,9 @@ Rails.application.routes.draw do
   post "items/backup" => "api/items#backup"
 
   delete "items" => "api/items#destroy"
-  resources "items", :controller => "api/items"
+  resources "items", :controller => "api/items" do
+    resources "revisions", :controller => "api/revisions"
+  end
 
   # sessions management
   post "session/refresh" => "api/sessions#refresh"

--- a/db/migrate/20200601101128_add_item_revisions.rb
+++ b/db/migrate/20200601101128_add_item_revisions.rb
@@ -5,6 +5,7 @@ class AddItemRevisions < ActiveRecord::Migration[5.1]
       t.string "item_uuid", limit: 36, null: false
       t.string "revision_uuid", limit: 36, null: false
       t.index ["item_uuid"]
+      t.index ["revision_uuid"]
     end
 
     create_table "revisions", id: false do |t|

--- a/db/migrate/20200601101128_add_item_revisions.rb
+++ b/db/migrate/20200601101128_add_item_revisions.rb
@@ -12,6 +12,7 @@ class AddItemRevisions < ActiveRecord::Migration[5.1]
       t.string "uuid", limit: 36, primary_key: true, null: false
       t.text "content", limit: 16.megabytes - 1
       t.string "content_type"
+      t.string "items_key_id"
       t.text "enc_item_key"
       t.string "auth_hash"
       t.datetime "created_at", precision: 6

--- a/db/migrate/20200601101128_add_item_revisions.rb
+++ b/db/migrate/20200601101128_add_item_revisions.rb
@@ -1,0 +1,21 @@
+class AddItemRevisions < ActiveRecord::Migration[5.1]
+  def change
+    create_table "item_revisions", id: false do |t|
+      t.string "uuid", limit: 36, primary_key: true, null: false
+      t.string "item_uuid", limit: 36, null: false
+      t.string "revision_uuid", limit: 36, null: false
+      t.index ["item_uuid"]
+    end
+
+    create_table "revisions", id: false do |t|
+      t.string "uuid", limit: 36, primary_key: true, null: false
+      t.text "content", limit: 16.megabytes - 1
+      t.string "content_type"
+      t.text "enc_item_key"
+      t.string "auth_hash"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
+      t.index ["created_at"]
+    end
+  end
+end

--- a/db/migrate/20200605085931_add_duplicate_of_to_items.rb
+++ b/db/migrate/20200605085931_add_duplicate_of_to_items.rb
@@ -1,0 +1,5 @@
+class AddDuplicateOfToItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :items, :duplicate_of, :string, limit: 36, :after => :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,8 +28,8 @@ ActiveRecord::Schema.define(version: 20200605085931) do
   end
 
   create_table "items", primary_key: "uuid", id: :string, limit: 36, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string "items_key_id"
     t.string "duplicate_of", limit: 36
+    t.string "items_key_id"
     t.text "content", limit: 16777215
     t.string "content_type"
     t.text "enc_item_key"
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 20200605085931) do
   create_table "revisions", primary_key: "uuid", id: :string, limit: 36, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.text "content", limit: 16777215
     t.string "content_type"
+    t.string "items_key_id"
     t.text "enc_item_key"
     t.string "auth_hash"
     t.datetime "created_at", precision: 6

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200410020904) do
+ActiveRecord::Schema.define(version: 20200605085931) do
 
   create_table "extension_settings", primary_key: "uuid", id: :string, limit: 36, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "extension_id"
@@ -20,8 +20,16 @@ ActiveRecord::Schema.define(version: 20200410020904) do
     t.index ["extension_id"], name: "index_extension_settings_on_extension_id"
   end
 
+  create_table "item_revisions", primary_key: "uuid", id: :string, limit: 36, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "item_uuid", limit: 36, null: false
+    t.string "revision_uuid", limit: 36, null: false
+    t.index ["item_uuid"], name: "index_item_revisions_on_item_uuid"
+    t.index ["revision_uuid"], name: "index_item_revisions_on_revision_uuid"
+  end
+
   create_table "items", primary_key: "uuid", id: :string, limit: 36, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "items_key_id"
+    t.string "duplicate_of", limit: 36
     t.text "content", limit: 16777215
     t.string "content_type"
     t.text "enc_item_key"
@@ -39,6 +47,16 @@ ActiveRecord::Schema.define(version: 20200410020904) do
     t.index ["user_uuid"], name: "index_items_on_user_uuid"
   end
 
+  create_table "revisions", primary_key: "uuid", id: :string, limit: 36, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.text "content", limit: 16777215
+    t.string "content_type"
+    t.text "enc_item_key"
+    t.string "auth_hash"
+    t.datetime "created_at", precision: 6
+    t.datetime "updated_at", precision: 6
+    t.index ["created_at"], name: "index_revisions_on_created_at"
+  end
+
   create_table "sessions", primary_key: "uuid", id: :string, limit: 36, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "user_uuid"
     t.text "user_agent"
@@ -48,6 +66,8 @@ ActiveRecord::Schema.define(version: 20200410020904) do
     t.datetime "expire_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["access_token"], name: "index_sessions_on_access_token", unique: true
+    t.index ["refresh_token"], name: "index_sessions_on_refresh_token", unique: true
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
     t.index ["user_uuid"], name: "index_sessions_on_user_uuid"
   end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@ version: '3'
 services:
   app:
     build: .
-    depends_on:
-      - db
     command: bash -c "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"
     env_file: .env
     restart: unless-stopped
@@ -11,6 +9,10 @@ services:
       DB_HOST: db
     ports:
       - ${EXPOSED_PORT}:3000
+    volumes:
+      - .:/syncing-server
+    links:
+      - db
   db:
     image: mysql:5.7
     environment:
@@ -19,9 +21,10 @@ services:
       MYSQL_PASSWORD: '${DB_PASSWORD}'
       MYSQL_ROOT_PASSWORD: '${DB_ROOT_PASSWORD}'
     expose:
-      - '3306'
+      - 3306
+    ports:
+      - 3306
     restart: unless-stopped
+    command: --default-authentication-plugin=mysql_native_password --character-set-server=utf8 --collation-server=utf8_general_ci
     volumes:
-      - std_notes_db:/var/lib/mysql
-volumes:
-  std_notes_db:
+      - ./data:/var/lib/mysql

--- a/lib/sync_engine/abstract/sync_manager.rb
+++ b/lib/sync_engine/abstract/sync_manager.rb
@@ -8,7 +8,7 @@ module SyncEngine
     end
 
     def sync_fields
-      @sync_fields || [:content, :items_key_id, :enc_item_key, :content_type, :auth_hash, :deleted, :created_at]
+      @sync_fields || [:content, :items_key_id, :enc_item_key, :content_type, :auth_hash, :deleted, :created_at, :duplicate_of]
     end
 
     def destroy_items(uuids)

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -134,7 +134,6 @@ RSpec.describe Api::ItemsController, type: :controller do
             expect(revisions.count).to equal(3)
             expect(revisions[0].content).to eq('This is yet another new content.')
             expect(revisions[1].content).to eq('This is the new content.')
-            expect(revisions[2].content).to eq('This is a test note.')
           end
         end
 

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -121,17 +121,18 @@ RSpec.describe Api::ItemsController, type: :controller do
 
             # Serializing the items into an array of hashes
             items_param = test_items.limit(1).to_a.map(&:serializable_hash)
-            items_param[0]['content'] = 'This is the new content.'
 
+            items_param[0]['content'] = 'This is the new content.'
             post :sync, params: { sync_token: '', cursor_token: '', limit: 5, api: '20190520', items: items_param }
 
+            sleep 1
             items_param[0]['content'] = 'This is yet another new content.'
             post :sync, params: { sync_token: '', cursor_token: '', limit: 5, api: '20190520', items: items_param }
 
             item = Item.where(uuid: items_param[0]['uuid']).first
 
             revisions = item.revisions
-            expect(revisions.count).to equal(3)
+            expect(revisions.count).to eq(3)
             expect(revisions[0].content).to eq('This is yet another new content.')
             expect(revisions[1].content).to eq('This is the new content.')
           end

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -144,6 +144,21 @@ RSpec.describe Api::ItemsController, type: :controller do
             expect(revisions[0].content).to eq('This is yet another new content.')
             expect(revisions[1].content).to eq('This is the new content.')
           end
+          it 'should duplicate revisions for a conflicting item' do
+            @controller = Api::AuthController.new
+            post :sign_in, params: test_user_credentials
+
+            @controller = Api::ItemsController.new
+            request.headers['Authorization'] = "bearer #{JSON.parse(response.body)['token']}"
+
+            items_param = [note_item].to_a.map(&:serializable_hash)
+            items_param[0]['duplicate_of'] = '1-2-3'
+
+            post :sync, params: { sync_token: '', cursor_token: '', limit: 5, api: '20190520', items: items_param }
+            expect(response).to have_http_status(:success)
+
+            expect(DuplicateRevisionsJob).to have_been_enqueued.with(note_item.uuid)
+          end
         end
 
         context 'and deleting items' do

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -125,7 +125,6 @@ RSpec.describe Api::ItemsController, type: :controller do
             items_param[0]['content'] = 'This is the new content.'
             post :sync, params: { sync_token: '', cursor_token: '', limit: 5, api: '20190520', items: items_param }
 
-            sleep 1
             items_param[0]['content'] = 'This is yet another new content.'
             post :sync, params: { sync_token: '', cursor_token: '', limit: 5, api: '20190520', items: items_param }
 

--- a/spec/controllers/api/revisions_controller_spec.rb
+++ b/spec/controllers/api/revisions_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Api::RevisionsController, type: :controller do
       it 'should return item revisions' do
         item = test_items.first
 
-        revision = create(:revision, content: 'This is a first revision', user_uuid: test_user.uuid)
+        revision = create(:revision, content: 'This is a first revision')
         create(:item_revision, item_uuid: item.uuid, revision_uuid: revision.uuid)
 
         @controller = Api::AuthController.new
@@ -108,7 +108,7 @@ RSpec.describe Api::RevisionsController, type: :controller do
       it 'should return a specific revision' do
         item = test_items.first
 
-        revision = create(:revision, content: 'This is a first revision', user_uuid: test_user.uuid)
+        revision = create(:revision, content: 'This is a first revision')
         create(:item_revision, item_uuid: item.uuid, revision_uuid: revision.uuid)
 
         @controller = Api::AuthController.new

--- a/spec/controllers/api/revisions_controller_spec.rb
+++ b/spec/controllers/api/revisions_controller_spec.rb
@@ -68,64 +68,6 @@ RSpec.describe Api::RevisionsController, type: :controller do
 
         expect(response).to have_http_status(:not_found)
       end
-      it 'should return limited item revisions' do
-        amount_of_days = 35
-        amount_of_revisions_per_day = 40
-
-        amount_of_days.times do |days_from_today|
-          random_content = (0...8).map { (65 + rand(26)).chr }.join
-          revisions = create_list(
-            :revision,
-            amount_of_revisions_per_day,
-            content: random_content,
-            created_at: days_from_today.days.ago
-          )
-          revisions.each do |revision|
-            create(:item_revision, item_uuid: test_items.first.uuid, revision_uuid: revision.uuid)
-          end
-        end
-
-        @controller = Api::AuthController.new
-        post :sign_in, params: test_user_credentials
-
-        request.headers['Authorization'] = "bearer #{JSON.parse(response.body)['token']}"
-
-        @controller = Api::ItemsController.new
-        items_param = [test_items.first].to_a.map(&:serializable_hash)
-        items_param[0]['content'] = 'This is the new content.'
-        post :sync, params: { sync_token: '', cursor_token: '', limit: 5, api: '20190520', items: items_param }
-
-        @controller = Api::RevisionsController.new
-        get :index, params: { item_id: test_items.first.uuid }
-
-        expect(response).to have_http_status(:success)
-        expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
-
-        revisions = JSON.parse(response.body)
-        expect(revisions.length).to eq(466)
-
-        revisions_by_date = {}
-        revisions.each do |revision|
-          unless revisions_by_date[revision['created_at'].to_date]
-            revisions_by_date[revision['created_at'].to_date] = []
-          end
-          revisions_by_date[revision['created_at'].to_date].push(revision)
-        end
-
-        expected_revision_counts = []
-        (1..30).reverse_each do |n|
-          if n < 2
-            n = 2
-          end
-          expected_revision_counts.push(n)
-        end
-
-        index = 0
-        revisions_by_date.each do |_date, revisions_in_date|
-          expect(revisions_in_date.length).to eq(expected_revision_counts[index])
-          index += 1
-        end
-      end
     end
   end
 

--- a/spec/controllers/api/revisions_controller_spec.rb
+++ b/spec/controllers/api/revisions_controller_spec.rb
@@ -1,0 +1,128 @@
+require 'rails_helper'
+
+RSpec.describe Api::RevisionsController, type: :controller do
+  test_password = '123456'
+
+  let(:test_user) do
+    build(:user, password: test_password)
+  end
+
+  before(:each) do
+    test_user.save
+
+    create_list(:item, 10, :note_type, user_uuid: test_user.uuid, content: 'This is a test note.')
+  end
+
+  let(:test_user_credentials) do
+    { email: test_user.email, password: test_password }
+  end
+
+  let(:test_items) do
+    Item.where(user_uuid: test_user.uuid)
+  end
+
+  describe 'GET item revisions' do
+    context 'when not signed in' do
+      it 'should return unauthorized error' do
+        item = test_items.first
+        get :index, params: { item_id: item.uuid }
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
+
+        parsed_response_body = JSON.parse(response.body)
+
+        expect(parsed_response_body).to_not be_nil
+        expect(parsed_response_body['error']).to_not be_nil
+        expect(parsed_response_body['error']['message']).to eq('Invalid login credentials.')
+        expect(parsed_response_body['error']['tag']).to eq('invalid-auth')
+      end
+    end
+    context 'when signed in' do
+      it 'should return item revisions' do
+        item = test_items.first
+
+        revision = create(:revision, content: 'This is a first revision', user_uuid: test_user.uuid)
+        create(:item_revision, item_uuid: item.uuid, revision_uuid: revision.uuid)
+
+        @controller = Api::AuthController.new
+        post :sign_in, params: test_user_credentials
+
+        @controller = Api::RevisionsController.new
+        request.headers['Authorization'] = "bearer #{JSON.parse(response.body)['token']}"
+
+        get :index, params: { item_id: item.uuid }
+
+        expect(response).to have_http_status(:success)
+        expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
+        expect(JSON.parse(response.body).first['content']).to eq('This is a first revision')
+      end
+      it 'should return limited item revisions' do
+        item = test_items.first
+
+        35.times do |days_from_today|
+          revisions = create_list(
+            :revision,
+            10,
+            content: (0...8).map { (65 + rand(26)).chr }.join,
+            created_at: days_from_today.days.ago
+          )
+          revisions.each do |revision|
+            create(:item_revision, item_uuid: item.uuid, revision_uuid: revision.uuid)
+          end
+        end
+
+        @controller = Api::AuthController.new
+        post :sign_in, params: test_user_credentials
+
+        @controller = Api::RevisionsController.new
+        request.headers['Authorization'] = "bearer #{JSON.parse(response.body)['token']}"
+
+        get :index, params: { item_id: item.uuid }
+
+        expect(response).to have_http_status(:success)
+        expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
+        expect(JSON.parse(response.body).length).to eq(180)
+      end
+    end
+  end
+
+  describe 'GET a specific revision' do
+    context 'when not signed in' do
+      it 'should return unauthorized error' do
+        item = test_items.first
+        get :show, params: { item_id: item.uuid, id: '12345' }
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
+
+        parsed_response_body = JSON.parse(response.body)
+
+        expect(parsed_response_body).to_not be_nil
+        expect(parsed_response_body['error']).to_not be_nil
+        expect(parsed_response_body['error']['message']).to eq('Invalid login credentials.')
+        expect(parsed_response_body['error']['tag']).to eq('invalid-auth')
+      end
+    end
+    context 'when signed in' do
+      it 'should return a specific revision' do
+        item = test_items.first
+
+        revision = create(:revision, content: 'This is a first revision', user_uuid: test_user.uuid)
+        create(:item_revision, item_uuid: item.uuid, revision_uuid: revision.uuid)
+
+        @controller = Api::AuthController.new
+        post :sign_in, params: test_user_credentials
+
+        @controller = Api::RevisionsController.new
+        request.headers['Authorization'] = "bearer #{JSON.parse(response.body)['token']}"
+
+        get :show, params: { item_id: item.uuid, id: revision.uuid }
+
+        expect(response).to have_http_status(:success)
+        expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
+        expect(JSON.parse(response.body)['content']).to eq('This is a first revision')
+      end
+    end
+  end
+end

--- a/spec/controllers/api/revisions_controller_spec.rb
+++ b/spec/controllers/api/revisions_controller_spec.rb
@@ -69,17 +69,19 @@ RSpec.describe Api::RevisionsController, type: :controller do
         expect(response).to have_http_status(:not_found)
       end
       it 'should return limited item revisions' do
-        item = test_items.first
+        amount_of_days = 35
+        amount_of_revisions_per_day = 40
 
-        35.times do |days_from_today|
+        amount_of_days.times do |days_from_today|
+          random_content = (0...8).map { (65 + rand(26)).chr }.join
           revisions = create_list(
             :revision,
-            10,
-            content: (0...8).map { (65 + rand(26)).chr }.join,
+            amount_of_revisions_per_day,
+            content: random_content,
             created_at: days_from_today.days.ago
           )
           revisions.each do |revision|
-            create(:item_revision, item_uuid: item.uuid, revision_uuid: revision.uuid)
+            create(:item_revision, item_uuid: test_items.first.uuid, revision_uuid: revision.uuid)
           end
         end
 
@@ -89,16 +91,40 @@ RSpec.describe Api::RevisionsController, type: :controller do
         request.headers['Authorization'] = "bearer #{JSON.parse(response.body)['token']}"
 
         @controller = Api::ItemsController.new
-        items_param = [item].to_a.map(&:serializable_hash)
+        items_param = [test_items.first].to_a.map(&:serializable_hash)
         items_param[0]['content'] = 'This is the new content.'
         post :sync, params: { sync_token: '', cursor_token: '', limit: 5, api: '20190520', items: items_param }
 
         @controller = Api::RevisionsController.new
-        get :index, params: { item_id: item.uuid }
+        get :index, params: { item_id: test_items.first.uuid }
 
         expect(response).to have_http_status(:success)
         expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
-        expect(JSON.parse(response.body).length).to eq(151)
+
+        revisions = JSON.parse(response.body)
+        expect(revisions.length).to eq(466)
+
+        revisions_by_date = {}
+        revisions.each do |revision|
+          unless revisions_by_date[revision['created_at'].to_date]
+            revisions_by_date[revision['created_at'].to_date] = []
+          end
+          revisions_by_date[revision['created_at'].to_date].push(revision)
+        end
+
+        expected_revision_counts = []
+        (1..30).reverse_each do |n|
+          if n < 2
+            n = 2
+          end
+          expected_revision_counts.push(n)
+        end
+
+        index = 0
+        revisions_by_date.each do |_date, revisions_in_date|
+          expect(revisions_in_date.length).to eq(expected_revision_counts[index])
+          index += 1
+        end
       end
     end
   end

--- a/spec/factories/item_revision.rb
+++ b/spec/factories/item_revision.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :item_revision do
+  end
+end

--- a/spec/factories/revision.rb
+++ b/spec/factories/revision.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :revision do
+  end
+end

--- a/spec/jobs/cleanup_revisions_job_spec.rb
+++ b/spec/jobs/cleanup_revisions_job_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe CleanupRevisionsJob do
+  subject do
+    described_class.new
+  end
+
+  let(:test_user) do
+    create(:user, password: '123456')
+  end
+
+  let(:test_item) do
+    create(:item, :note_type, user_uuid: test_user.uuid, content: 'This is a test note.')
+  end
+
+  before(:each) do
+    amount_of_days = 35
+    amount_of_revisions_per_day = 40
+
+    amount_of_days.times do |days_from_today|
+      random_content = (0...8).map { (65 + rand(26)).chr }.join
+      revisions = create_list(
+        :revision,
+        amount_of_revisions_per_day,
+        content: random_content,
+        created_at: days_from_today.days.ago
+      )
+      revisions.each do |revision|
+        create(:item_revision, item_uuid: test_item.uuid, revision_uuid: revision.uuid)
+      end
+    end
+  end
+
+  it 'should clean up revisions from last 30 days' do
+    subject.perform(test_item.uuid, 30)
+
+    revisions = test_item.revisions.where(created_at: 30.days.ago..DateTime::Infinity.new)
+    expect(revisions.length).to eq(466)
+  end
+
+  it 'should clean up revisions in a decaying fashion for last 30 days' do
+    subject.perform(test_item.uuid, 30)
+
+    revisions = test_item.revisions.where(created_at: 30.days.ago..DateTime::Infinity.new)
+
+    revisions_by_date = {}
+    revisions.each do |revision|
+      unless revisions_by_date[revision['created_at'].to_date]
+        revisions_by_date[revision['created_at'].to_date] = []
+      end
+      revisions_by_date[revision['created_at'].to_date].push(revision)
+    end
+
+    expected_revision_counts = []
+    (1..30).reverse_each do |n|
+      if n < 2
+        n = 2
+      end
+      expected_revision_counts.push(n)
+    end
+
+    index = 0
+    revisions_by_date.each do |_date, revisions_in_date|
+      expect(revisions_in_date.length).to eq(expected_revision_counts[index])
+      index += 1
+    end
+  end
+end

--- a/spec/jobs/cleanup_revisions_job_spec.rb
+++ b/spec/jobs/cleanup_revisions_job_spec.rb
@@ -13,62 +13,119 @@ RSpec.describe CleanupRevisionsJob do
     create(:item, :note_type, user_uuid: test_user.uuid, content: 'This is a test note.')
   end
 
-  before(:each) do
-    amount_of_days = 35
-    amount_of_revisions_per_day = 40
+  describe 'continues 30 days data' do
+    before(:each) do
+      amount_of_days = 35
+      amount_of_revisions_per_day = 40
 
-    amount_of_days.times do |days_from_today|
-      revisions = []
+      amount_of_days.times do |days_from_today|
+        revisions = []
 
-      amount_of_revisions_per_day.times do |n|
-        revisions.push(
-          create(
-            :revision,
-            uuid: "#{days_from_today}-#{n}",
-            content: (0...8).map { (65 + rand(26)).chr }.join,
-            created_at: days_from_today.days.ago
+        amount_of_revisions_per_day.times do |n|
+          revisions.push(
+            create(
+              :revision,
+              uuid: "#{days_from_today}-#{n}",
+              content: (0...8).map { (65 + rand(26)).chr }.join,
+              created_at: days_from_today.days.ago
+            )
           )
-        )
-      end
+        end
 
+        revisions.each do |revision|
+          create(:item_revision, item_uuid: test_item.uuid, revision_uuid: revision.uuid)
+        end
+      end
+    end
+
+    it 'should clean up revisions from last 30 days' do
+      subject.perform(test_item.uuid, 30)
+
+      revisions = test_item.revisions.where(created_at: 30.days.ago..DateTime::Infinity.new)
+      expect(revisions.length).to eq(466)
+    end
+
+    it 'should clean up revisions in a decaying fashion for last 30 days' do
+      subject.perform(test_item.uuid, 30)
+
+      revisions = test_item.revisions.where(created_at: 30.days.ago..DateTime::Infinity.new)
+
+      revisions_by_date = {}
       revisions.each do |revision|
-        create(:item_revision, item_uuid: test_item.uuid, revision_uuid: revision.uuid)
+        unless revisions_by_date[revision['created_at'].to_date]
+          revisions_by_date[revision['created_at'].to_date] = []
+        end
+        revisions_by_date[revision['created_at'].to_date].push(revision)
+      end
+
+      expected_revision_counts = []
+      (1..30).reverse_each do |n|
+        if n < 2
+          n = 2
+        end
+        expected_revision_counts.push(n)
+      end
+
+      index = 0
+      revisions_by_date.each do |_date, revisions_in_date|
+        expect(revisions_in_date.length).to eq(expected_revision_counts[index])
+        index += 1
       end
     end
   end
 
-  it 'should clean up revisions from last 30 days' do
-    subject.perform(test_item.uuid, 30)
+  describe 'sparse 30 days data - infrequent editting' do
+    before(:each) do
+      sparse_days_from_today = (10..55).step(5)
+      amount_of_revisions_per_day = 40
 
-    revisions = test_item.revisions.where(created_at: 30.days.ago..DateTime::Infinity.new)
-    expect(revisions.length).to eq(466)
-  end
+      sparse_days_from_today.each do |days_from_today|
+        revisions = create_list(
+          :revision,
+          amount_of_revisions_per_day,
+          content: (0...8).map { (65 + rand(26)).chr }.join,
+          created_at: days_from_today.days.ago
+        )
 
-  it 'should clean up revisions in a decaying fashion for last 30 days' do
-    subject.perform(test_item.uuid, 30)
-
-    revisions = test_item.revisions.where(created_at: 30.days.ago..DateTime::Infinity.new)
-
-    revisions_by_date = {}
-    revisions.each do |revision|
-      unless revisions_by_date[revision['created_at'].to_date]
-        revisions_by_date[revision['created_at'].to_date] = []
+        revisions.each do |revision|
+          create(:item_revision, item_uuid: test_item.uuid, revision_uuid: revision.uuid)
+        end
       end
-      revisions_by_date[revision['created_at'].to_date].push(revision)
     end
 
-    expected_revision_counts = []
-    (1..30).reverse_each do |n|
-      if n < 2
-        n = 2
-      end
-      expected_revision_counts.push(n)
+    it 'should clean up revisions from last 30 days' do
+      subject.perform(test_item.uuid, 30)
+
+      revisions = test_item.revisions.where(created_at: 30.days.ago..DateTime::Infinity.new)
+      expect(revisions.length).to eq(51)
     end
 
-    index = 0
-    revisions_by_date.each do |_date, revisions_in_date|
-      expect(revisions_in_date.length).to eq(expected_revision_counts[index])
-      index += 1
+    it 'should clean up revisions in a decaying fashion for last 30 days' do
+      subject.perform(test_item.uuid, 30)
+
+      revisions = test_item.revisions.where(created_at: 30.days.ago..DateTime::Infinity.new)
+
+      revisions_by_date = {}
+      revisions.each do |revision|
+        unless revisions_by_date[revision['created_at'].to_date]
+          revisions_by_date[revision['created_at'].to_date] = []
+        end
+        revisions_by_date[revision['created_at'].to_date].push(revision)
+      end
+
+      expected_revision_counts = {
+        DateTime.now.strftime('%Y-%m-%d') => 1,
+        10.days.ago.strftime('%Y-%m-%d') => 20,
+        15.days.ago.strftime('%Y-%m-%d') => 15,
+        20.days.ago.strftime('%Y-%m-%d') => 10,
+        25.days.ago.strftime('%Y-%m-%d') => 5,
+      }
+
+      index = 0
+      revisions_by_date.each do |date, revisions_in_date|
+        expect(expected_revision_counts[date.to_s]).to eq(revisions_in_date.length)
+        index += 1
+      end
     end
   end
 end

--- a/spec/jobs/cleanup_revisions_job_spec.rb
+++ b/spec/jobs/cleanup_revisions_job_spec.rb
@@ -18,13 +18,19 @@ RSpec.describe CleanupRevisionsJob do
     amount_of_revisions_per_day = 40
 
     amount_of_days.times do |days_from_today|
-      random_content = (0...8).map { (65 + rand(26)).chr }.join
-      revisions = create_list(
-        :revision,
-        amount_of_revisions_per_day,
-        content: random_content,
-        created_at: days_from_today.days.ago
-      )
+      revisions = []
+
+      amount_of_revisions_per_day.times do |n|
+        revisions.push(
+          create(
+            :revision,
+            uuid: "#{days_from_today}-#{n}",
+            content: (0...8).map { (65 + rand(26)).chr }.join,
+            created_at: days_from_today.days.ago
+          )
+        )
+      end
+
       revisions.each do |revision|
         create(:item_revision, item_uuid: test_item.uuid, revision_uuid: revision.uuid)
       end

--- a/spec/jobs/duplicate_revisions_job_spec.rb
+++ b/spec/jobs/duplicate_revisions_job_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe DuplicateRevisionsJob do
+  subject do
+    described_class.new
+  end
+
+  let(:test_user) do
+    create(:user, password: '123456')
+  end
+
+  let(:original_item) do
+    create(:item, :note_type, user_uuid: test_user.uuid, content: 'This is a test note.')
+  end
+
+  let(:amount_of_revisions_to_generate) do
+    40
+  end
+
+  before(:each) do
+    amount_of_revisions_to_generate.times do
+      original_item.content = (0...8).map { (65 + rand(26)).chr }.join
+      original_item.save
+    end
+  end
+
+  it 'should duplicate revisions onto a duplicate item' do
+    duplicate_item = create(
+      :item,
+      :note_type,
+      duplicate_of: original_item.uuid,
+      user_uuid: test_user.uuid,
+      content: 'This is a test note.'
+    )
+
+    duplicate_item_revisions_before = ItemRevision.where(item_uuid: duplicate_item.uuid)
+    original_item_revisions_before = ItemRevision.where(item_uuid: original_item.uuid)
+
+    original_revisions_amount = 1 + amount_of_revisions_to_generate
+
+    expect(duplicate_item_revisions_before.length).to eq(1)
+    expect(original_item_revisions_before.length).to eq(original_revisions_amount)
+
+    subject.perform(duplicate_item.uuid)
+
+    duplicate_item_revisions_after = ItemRevision.where(item_uuid: duplicate_item.uuid)
+
+    expect(duplicate_item_revisions_after.length).to eq(1 + original_revisions_amount)
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Item, type: :model do
     end
 
     let(:hash_keys) do
-      %w[uuid auth_hash content content_type created_at deleted enc_item_key updated_at items_key_id].sort
+      %w[uuid auth_hash content content_type created_at deleted enc_item_key updated_at items_key_id duplicate_of].sort
     end
 
     specify do


### PR DESCRIPTION
Whenever an item is saved it will save a new revision of the item.

2 new API endpoints are created for retrieving revisions:

```
GET /items/:item_id/revisions
GET /items/:item_id/revisions/:id
```

Items to Revisions relation is many to many for the purpose of creating duplicates of items and assigning existing revisions to them.

I've also updated the local `docker-compose` setup by:
- mounting the local source code as a volume to the app container (changes in code will reflect in the running container)
- mounting `data/` folder for persisting database entries between container runs