### PR TITLE
Fix saving revisions to previous content

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -84,11 +84,11 @@ class Item < ApplicationRecord
   def persist_revision
     if content_type == 'Note'
       revision = Revision.new
-      revision.content = content
-      revision.content_type = content_type
-      revision.enc_item_key = enc_item_key
-      revision.items_key_id = items_key_id
-      revision.auth_hash = auth_hash
+      revision.content = content_was
+      revision.content_type = content_type_was
+      revision.enc_item_key = enc_item_key_was
+      revision.items_key_id = items_key_id_was
+      revision.auth_hash = auth_hash_was
       revision.save
 
       item_revision = ItemRevision.new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -82,7 +82,7 @@ class Item < ApplicationRecord
   end
 
   def persist_revision
-    if content_type == 'Note'
+    if content_type == 'Note' && uuid? && content?
       revision = Revision.new
       revision.content = content_before_last_save
       revision.content_type = content_type_before_last_save

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -82,7 +82,7 @@ class Item < ApplicationRecord
   end
 
   def persist_revision
-    if content_type == 'Note' && uuid? && content?
+    if content_type == 'Note' && !uuid_before_last_save.nil?
       revision = Revision.new
       revision.content = content_before_last_save
       revision.content_type = content_type_before_last_save

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -84,11 +84,11 @@ class Item < ApplicationRecord
   def persist_revision
     if content_type == 'Note'
       revision = Revision.new
-      revision.content = content_was
-      revision.content_type = content_type_was
-      revision.enc_item_key = enc_item_key_was
-      revision.items_key_id = items_key_id_was
-      revision.auth_hash = auth_hash_was
+      revision.content = content_before_last_save
+      revision.content_type = content_type_before_last_save
+      revision.enc_item_key = enc_item_key_before_last_save
+      revision.items_key_id = items_key_id_before_last_save
+      revision.auth_hash = auth_hash_before_last_save
       revision.save
 
       item_revision = ItemRevision.new

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -141,8 +141,9 @@ RSpec.describe Api::ItemsController, type: :controller do
 
             expect(CleanupRevisionsJob).to have_been_enqueued.with(item.uuid, 30).exactly(3).times
             expect(revisions.count).to eq(3)
-            expect(revisions[0].content).to eq('This is yet another new content.')
-            expect(revisions[1].content).to eq('This is the new content.')
+            expect(revisions[0].content).to eq('This is the new content.')
+            expect(revisions[1].content).to eq(note_item.content)
+            expect(revisions[2].content).to eq(nil)
           end
         end
 

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -140,10 +140,9 @@ RSpec.describe Api::ItemsController, type: :controller do
             revisions = item.revisions
 
             expect(CleanupRevisionsJob).to have_been_enqueued.with(item.uuid, 30).exactly(3).times
-            expect(revisions.count).to eq(3)
+            expect(revisions.count).to eq(2)
             expect(revisions[0].content).to eq('This is the new content.')
             expect(revisions[1].content).to eq(note_item.content)
-            expect(revisions[2].content).to eq(nil)
           end
         end
 

--- a/spec/jobs/cleanup_revisions_job_spec.rb
+++ b/spec/jobs/cleanup_revisions_job_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe CleanupRevisionsJob do
       subject.perform(test_item.uuid, 30)
 
       revisions = test_item.revisions.where(created_at: 30.days.ago..DateTime::Infinity.new)
-      expect(revisions.length).to eq(51)
+      expect(revisions.length).to eq(50)
     end
 
     it 'should clean up revisions in a decaying fashion for last 30 days' do

--- a/spec/jobs/duplicate_revisions_job_spec.rb
+++ b/spec/jobs/duplicate_revisions_job_spec.rb
@@ -32,19 +32,14 @@ RSpec.describe DuplicateRevisionsJob do
       user_uuid: test_user.uuid,
       content: 'This is a test note.'
     )
-
-    duplicate_item_revisions_before = ItemRevision.where(item_uuid: duplicate_item.uuid)
     original_item_revisions_before = ItemRevision.where(item_uuid: original_item.uuid)
 
-    original_revisions_amount = 1 + amount_of_revisions_to_generate
-
-    expect(duplicate_item_revisions_before.length).to eq(1)
-    expect(original_item_revisions_before.length).to eq(original_revisions_amount)
+    expect(original_item_revisions_before.length).to eq(amount_of_revisions_to_generate)
 
     subject.perform(duplicate_item.uuid)
 
     duplicate_item_revisions_after = ItemRevision.where(item_uuid: duplicate_item.uuid)
 
-    expect(duplicate_item_revisions_after.length).to eq(1 + original_revisions_amount)
+    expect(duplicate_item_revisions_after.length).to eq(amount_of_revisions_to_generate)
   end
 end


### PR DESCRIPTION
as discussed with @mobitar - we should be saving the `n-1` state of the item as a revision the `n` state is preserved in the `item`.