### PR TITLE
Remove admin IP checking from within the application

### DIFF
--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -1,14 +1,8 @@
 class Admin::AdminController < ApplicationController
   before_action do
-    allowed_ips = ENV['ADMIN_IPS'].split(',')
-    is_authorized_ip = allowed_ips.include?(request.ip) && allowed_ips.include?(request.remote_ip)
-    if is_authorized_ip
-      admin_key = params[:admin_key]
-      env_admin_key = ENV['ADMIN_KEY']
-      if !admin_key || !env_admin_key || !ActiveSupport::SecurityUtils.secure_compare(admin_key, env_admin_key)
-        render json: {}, status: 401
-      end
-    else
+    admin_key = params[:admin_key]
+    env_admin_key = ENV['ADMIN_KEY']
+    if !admin_key || !env_admin_key || !ActiveSupport::SecurityUtils.secure_compare(admin_key, env_admin_key)
       render json: {}, status: 401
     end
   end

--- a/spec/controllers/admin/admin_controller_spec.rb
+++ b/spec/controllers/admin/admin_controller_spec.rb
@@ -3,22 +3,10 @@ require 'rails_helper'
 RSpec.describe Admin::AdminController, type: :controller do
   describe 'POST admin/delete_account' do
     before(:all) do
-      ENV['ADMIN_IPS'] = '192.168.0.1'
       ENV['ADMIN_KEY'] = 'secret_admin_key'
     end
 
-    it 'should throw unauthorized if not an authorized IP' do
-      controller.request.remote_addr = '1.2.3.4'
-
-      post :delete_account
-      expect(response).to have_http_status(:unauthorized)
-      expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
-      expect(JSON.parse(response.body)).to eq({})
-    end
-
     it 'should throw unauthorized if not admin_key is not valid' do
-      controller.request.remote_addr = ENV['ADMIN_IPS']
-
       post :delete_account, params: { admin_key: 'something_else' }
       expect(response).to have_http_status(:unauthorized)
       expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
@@ -26,8 +14,6 @@ RSpec.describe Admin::AdminController, type: :controller do
     end
 
     it 'deletes the user if found' do
-      controller.request.remote_addr = ENV['ADMIN_IPS']
-
       user_manager = SyncEngine::V20190520::UserManager.new(User)
       params = ActionController::Parameters.new(
         pw_cost: 110_000,


### PR DESCRIPTION
Removing the IP checking since it is not the application's responsibility to check the network/security layer. Prevents the applications from scaling out (in particular the source of the requests coming in): https://12factor.net/concurrency

Since we have set up AWS Web Application Firewall to restrict access to that area - this check is redundant.