### PR TITLE
fix: cleanup docker setup and server pid locking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,21 @@
 FROM ruby:2.6.5-slim-stretch
-LABEL Andy Duss <github@mindovermiles262>
+
 ARG optimize_for_raspberry_pi
 
-# Update System
 RUN apt-get update && \
   apt-get upgrade -y && \
   apt-get install -y git build-essential libmariadb-dev
 
-# Copy the syncing-server files
-COPY . /syncing-server
 WORKDIR /syncing-server
 
-# On Raspberry Pi, we should use bcrypt 3.1.12 instead of 3.1.13
-# within the Gemfile.lock file
+COPY Gemfile Gemfile.lock /syncing-server/
+
 RUN if [ "$optimize_for_raspberry_pi" = true ] ; then sed -i 's/bcrypt (3.1.13)/bcrypt (3.1.12)/g' Gemfile.lock; fi
 
-# Install gems
 RUN gem install bundler && bundle install
 
-# Migrate the DB and start development server
-CMD rm -f tmp/pids/server.pid && bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0
+COPY . /syncing-server
+
+ENTRYPOINT [ "docker/entrypoint.sh" ]
+
+CMD [ "start-web" ]

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -2,4 +2,4 @@ FROM standardnotes/syncing-server
 
 ENV SQS_QUEUE your-queue-name
 
-CMD bundle exec shoryuken -q $SQS_QUEUE -R
+CMD [ "start-worker" ]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+  'start-web' )
+    echo "Prestart Step 1/2 - Removing server lock"
+    rm -f /syncing-server/tmp/pids/server.pid
+    echo "Prestart Step 2/2 - Migrating database"
+    bundle exec rails db:migrate
+    echo "Starting Server..."
+    bundle exec rails server -b 0.0.0.0
+    ;;
+
+  'start-worker' )
+    echo "Starting Worker..."
+    bundle exec shoryuken -q $SQS_QUEUE -R
+    ;;
+
+   * )
+    echo "Unknown command"
+    ;;
+esac
+
+exec "$@"


### PR DESCRIPTION
This should fix the issue where server was restarting due to pid lock file being present: https://github.com/standardnotes/syncing-server/issues/68

Also cleans up the Dockerfile and adds a cache layer on the Ruby dependencies in Gemfile