### PR TITLE
fix: Running concurrent migrations in Rails 5.1.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
   app:
     build: .
+    command: start-local
     env_file: .env
     restart: unless-stopped
     environment:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,11 +2,23 @@
 set -e
 
 case "$1" in
+  'start-local' )
+    echo "Prestart Step 1/3 - Removing server lock"
+    rm -f /syncing-server/tmp/pids/server.pid
+    echo "Prestart Step 2/3 - Install dependencies"
+    bundle install
+    echo "Prestart Step 3/3 - Migrating database"
+    # bundle exec rails db:migrate
+    bundle exec rake db:migrate:ignore_concurrent
+    echo "Starting Server..."
+    bundle exec rails server -b 0.0.0.0
+    ;;
+
   'start-web' )
     echo "Prestart Step 1/2 - Removing server lock"
     rm -f /syncing-server/tmp/pids/server.pid
     echo "Prestart Step 2/2 - Migrating database"
-    bundle exec rails db:migrate
+    bundle exec rake db:migrate:ignore_concurrent
     echo "Starting Server..."
     bundle exec rails server -b 0.0.0.0
     ;;

--- a/lib/tasks/migrate_ignore_concurrent.rake
+++ b/lib/tasks/migrate_ignore_concurrent.rake
@@ -1,0 +1,14 @@
+# https://nebulab.it/blog/the-strange-case-of-activerecord-concurrentmigrationerror/
+
+namespace :db do
+  namespace :migrate do
+    desc 'Run db:migrate but ignore ActiveRecord::ConcurrentMigrationError errors'
+    task ignore_concurrent: :environment do
+      begin
+        Rake::Task['db:migrate'].invoke
+      rescue ActiveRecord::ConcurrentMigrationError
+        # Do nothing
+      end
+    end
+  end
+end


### PR DESCRIPTION
When running multiple containers we encounter an error about database advisory lock:

```
2020-07-02 15:06:52ActiveRecord::ConcurrentMigrationError:
2020-07-02 15:06:52Cannot run migrations because another migration process is currently running.
2020-07-02 15:06:52/usr/local/bundle/gems/activerecord-5.1.7/lib/active_record/migration.rb:1315:in `with_advisory_lock'
2020-07-02 15:06:52/usr/local/bundle/gems/activerecord-5.1.7/lib/active_record/migration.rb:1148:in `migrate'
2020-07-02 15:06:52/usr/local/bundle/gems/activerecord-5.1.7/lib/active_record/migration.rb:1007:in `up'
2020-07-02 15:06:52/usr/local/bundle/gems/activerecord-5.1.7/lib/active_record/migration.rb:985:in `migrate'
```

In Rails 6 you can disable the advisory lock to run migrations in an environment where you run multiple containers. Unfortunately in Rails 5.1.7 we have to do the workaround proposed in here: https://nebulab.it/blog/the-strange-case-of-activerecord-concurrentmigrationerror/