### PR TITLE
fix: server history response

### DIFF
--- a/app/controllers/api/revisions_controller.rb
+++ b/app/controllers/api/revisions_controller.rb
@@ -1,6 +1,15 @@
 class Api::RevisionsController < Api::ApiController
   def show
-    revision = current_user.items.find(params[:item_id]).revisions.find(params[:id])
+    begin
+      item = current_user.items.find(params[:item_id])
+    rescue ActiveRecord::RecordNotFound
+      return render json: { error: { message: 'Item not found' } }, status: :not_found
+    end
+
+    revision = item.revisions
+      .where(uuid: params[:id])
+      .select('revisions.*')
+      .first
 
     render json: revision
   end
@@ -12,6 +21,10 @@ class Api::RevisionsController < Api::ApiController
       return render json: { error: { message: 'Item not found' } }, status: :not_found
     end
 
-    render json: item.revisions.where(created_at: User::REVISIONS_RETENTION_DAYS.days.ago..DateTime::Infinity.new)
+    revisions = item.revisions
+      .where(created_at: User::REVISIONS_RETENTION_DAYS.days.ago..DateTime::Infinity.new)
+      .select('revisions.uuid, content_type, created_at, updated_at')
+
+    render json: revisions
   end
 end

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -1,4 +1,24 @@
 class Revision < ApplicationRecord
   has_many :item_revisions, foreign_key: 'revision_uuid', dependent: :destroy
   has_many :items, through: :item_revisions
+
+  def serializable_hash(options = {})
+    allowed_options = [
+      'uuid',
+      'items_key_id',
+      'duplicate_of',
+      'enc_item_key',
+      'content',
+      'content_type',
+      'auth_hash',
+      'deleted',
+      'created_at',
+      'updated_at',
+    ]
+
+    super(options.merge(only: allowed_options)).merge({
+      revision_uuid: uuid,
+      uuid: item_ids.first,
+    })
+  end
 end

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -17,8 +17,7 @@ class Revision < ApplicationRecord
     ]
 
     super(options.merge(only: allowed_options)).merge({
-      revision_uuid: uuid,
-      uuid: item_ids.first,
+      item_id: item_ids.first,
     })
   end
 end

--- a/spec/controllers/api/revisions_controller_spec.rb
+++ b/spec/controllers/api/revisions_controller_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe Api::RevisionsController, type: :controller do
 
         expect(response).to have_http_status(:success)
         expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
-        expect(JSON.parse(response.body).first['content']).to eq('This is a first revision')
+        parsed_response_body = JSON.parse(response.body)
+        expect(parsed_response_body).not_to include(content: 'This is a first revision')
       end
       it 'should return not found if an item does not exist' do
         @controller = Api::AuthController.new


### PR DESCRIPTION
For `/items/:item_id/revisions`

- [x] returns an array with the following structure:

```json
{
  "uuid": "<the item's uuid>",
  "content_type": "<content type field>",
  "revision_uuid": "<the revision's uuid>",
  "created_at": "<created_at field>",
  "updated_at": "<updated_at field>"
}
```

The goal is to prevent downloading the encrypted content for each revision. We should use `/items/:item_id/revisions/:revision_id` for this.

For `/items/:item_id/revisions/:revision_id`

- [x] returns a revision object and not an array of revisions
- [x] with the following structure:

```json
{
  "uuid": "<the item's uuid>",
  "items_key_id": "<items_key_id field>",
  "duplicate_of": "<duplicate_of field>",
  "enc_item_key": "<enc_item_key field>",
  "content": "<content field>",
  "auth_hash": "<auth_hash field>",
  "deleted": "<deleted field>",
  "content_type": "<content type field>",
  "revision_uuid": "<the revision's uuid>",
  "created_at": "<created_at field>",
  "updated_at": "<updated_at field>"
}
```