### PR TITLE
fix: no csrf

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,6 +1,4 @@
 class Api::ApiController < ApplicationController
-  respond_to :json
-
   attr_accessor :current_user
   attr_accessor :current_session
   attr_accessor :user_manager

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -1,6 +1,4 @@
 class Api::SessionsController < Api::ApiController
-  respond_to :json
-
   skip_before_action :authenticate_user, only: [:refresh]
   before_action :require_valid_session, except: [:refresh]
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,12 +2,14 @@ class ApplicationController < ActionController::API
   respond_to :json
 
   def route_not_found
-    render 'error_pages/404', status: :not_found
+    render json: {
+      message: 'Hi! the page you are looking for could not be found.',
+    }, status: :not_found
   end
 
   def home
     render json: {
-      message: "Hi! You're not supposed to be here."
+      message: "Hi! You're not supposed to be here.",
     }, status: :ok
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,18 +1,17 @@
-class ApplicationController < ActionController::Base
-  protect_from_forgery with: :null_session
-  after_action :set_csrf_cookie
-  respond_to :html, :json
-  layout :false
+class ApplicationController < ActionController::API
+  respond_to :json
 
   def route_not_found
     render 'error_pages/404', status: :not_found
   end
 
-  protected
-
-  def set_csrf_cookie
-    cookies['XSRF-TOKEN'] = form_authenticity_token if protect_against_forgery?
+  def home
+    render json: {
+      message: "Hi! You're not supposed to be here."
+    }, status: :ok
   end
+
+  protected
 
   def append_info_to_payload(payload)
     super


### PR DESCRIPTION
Basically, we don't need CSRF because this is a RESTful API server. No cookies are passed along requests; therefore, CSRF attacks are not even possible.

Closes #86 