### PR TITLE
fix: suggest cloning master branch in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can run your own Standard Notes server and use it with any Standard Notes ap
 1. Clone the project:
 
 	```
-	git clone https://github.com/standardnotes/syncing-server.git
+	git clone --branch master https://github.com/standardnotes/syncing-server.git
 	```
 
 1. Create a `.env` file in the project's root directory. See [env.sample](env.sample) for required values.


### PR DESCRIPTION
Many users trying to self-host do not change the branch from `develop` and get more errors than they should.
This PR changes the clone command to always default to the `master` branch.
Can be merged if approved