### PR TITLE
fix: revision response

### DIFF
--- a/app/controllers/api/revisions_controller.rb
+++ b/app/controllers/api/revisions_controller.rb
@@ -11,7 +11,9 @@ class Api::RevisionsController < Api::ApiController
       .select('revisions.*')
       .first
 
-    render json: revision
+    render json: {
+      revision: revision
+    }
   end
 
   def index
@@ -25,6 +27,8 @@ class Api::RevisionsController < Api::ApiController
       .where(created_at: User::REVISIONS_RETENTION_DAYS.days.ago..DateTime::Infinity.new)
       .select('revisions.uuid, content_type, created_at, updated_at')
 
-    render json: revisions
+    render json: {
+      revisions: revisions
+    }
   end
 end

--- a/spec/controllers/api/revisions_controller_spec.rb
+++ b/spec/controllers/api/revisions_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Api::RevisionsController, type: :controller do
         expect(response).to have_http_status(:success)
         expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
         parsed_response_body = JSON.parse(response.body)
-        expect(parsed_response_body).not_to include(content: 'This is a first revision')
+        expect(parsed_response_body['revisions']).not_to include(content: 'This is a first revision')
       end
       it 'should return not found if an item does not exist' do
         @controller = Api::AuthController.new
@@ -106,7 +106,8 @@ RSpec.describe Api::RevisionsController, type: :controller do
 
         expect(response).to have_http_status(:success)
         expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
-        expect(JSON.parse(response.body)['content']).to eq('This is a first revision')
+        parsed_response_body = JSON.parse(response.body)
+        expect(parsed_response_body['revision']['content']).to eq('This is a first revision')
       end
     end
   end


### PR DESCRIPTION
- [x] updates the response for the `/items/:item_id/revisions` endpoint
- [x] updates the response for the `/items/:item_id/revisions/:id` endpoint