### PR TITLE
fix: run docker without root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM ruby:2.6.5-alpine
 
 ARG optimize_for_raspberry_pi
+ARG UID=1000
+ARG GID=1000
+
+RUN addgroup -S snotes -g $GID && adduser -D -S snotes -G snotes -u $UID
 
 RUN apk add --update --no-cache \
     alpine-sdk \
@@ -9,13 +13,17 @@ RUN apk add --update --no-cache \
 
 WORKDIR /syncing-server
 
-COPY Gemfile Gemfile.lock /syncing-server/
+RUN chown -R $UID:$GID .
+
+USER snotes
+
+COPY --chown=$UID:$GID Gemfile Gemfile.lock /syncing-server/
 
 RUN if [ "$optimize_for_raspberry_pi" = true ] ; then sed -i 's/bcrypt (3.1.13)/bcrypt (3.1.12)/g' Gemfile.lock; fi
 
 RUN gem install bundler && bundle install
 
-COPY . /syncing-server
+COPY --chown=$UID:$GID . /syncing-server
 
 ENTRYPOINT [ "docker/entrypoint.sh" ]
 


### PR DESCRIPTION
Running processes as root is bad practice, following the principle of the least privilege. A process that runs at root in a container runs at root on the host (unless namespaces are used, which is not a common setup). Lots of people are just grabbing from Docker Hub, and passing the `--user` flag at runtime does not work out-of-the-box in that case.

Since we don't really need root privileges even for running the entrypoint script, I suggest we use the `USER` directive. `UID` and `GID` would still be customisable as arguments (`ARG`) so it's fairly convenient.

That works as intended for me, feel free to discuss if you want another approach!

```
# BEFORE
$ docker exec -ti snotes ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  0.0  0.0   1584     4 ?        Ss   Aug23   0:00 /bin/sh docker/
root        10  0.0  0.1 160188 93708 ?        Sl   Aug23   0:38 puma 4.3.3 (tcp
root        22  0.0  0.0   1616   488 pts/0    Rs+  01:30   0:00 ps aux

# AFTER
$ docker exec -ti snotes ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
snotes       1  0.1  0.0   1584  1076 ?        Ss   01:35   0:00 /bin/sh docker/
snotes      10  4.3  0.1 159200 92400 ?        Sl   01:35   0:01 puma 4.3.3 (tcp
snotes      22  0.0  0.0   1616   500 pts/0    Rs+  01:36   0:00 ps aux
```