### PR TITLE
fix: gracefully stop docker with tini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN addgroup -S snotes -g $GID && adduser -D -S snotes -G snotes -u $UID
 RUN apk add --update --no-cache \
     alpine-sdk \
     mariadb-dev \
+    tini \
     tzdata
 
 WORKDIR /syncing-server

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -12,7 +12,7 @@ case "$COMMAND" in
     echo "Prestart Step 3/3 - Migrating database"
     bundle exec rails db:migrate
     echo "Starting Server..."
-    bundle exec rails server -b 0.0.0.0
+    exec /sbin/tini -- bundle exec rails server -b 0.0.0.0
     ;;
 
   'start-web' )
@@ -21,22 +21,22 @@ case "$COMMAND" in
     echo "Prestart Step 2/2 - Migrating database"
     bundle exec rake db:migrate:ignore_concurrent
     echo "Starting Server..."
-    bundle exec rails server -b 0.0.0.0
+    exec /sbin/tini -- bundle exec rails server -b 0.0.0.0
     ;;
 
   'start-worker' )
     echo "Starting Worker..."
-    bundle exec shoryuken -q $SQS_QUEUE -R
+    exec /sbin/tini -- bundle exec shoryuken -q $SQS_QUEUE -R
     ;;
 
   'daily-backup' )
     echo "Starting Daily Backup..."
-    bundle exec rake "items:perform_daily_backup_jobs"
+    exec /sbin/tini -- bundle exec rake "items:perform_daily_backup_jobs"
     ;;
 
   'daily-backup-no-email' )
     echo "Starting Daily Backup Without Emails..."
-    bundle exec rake "items:perform_daily_backup_jobs[false]"
+    exec /sbin/tini -- bundle exec rake "items:perform_daily_backup_jobs[false]"
     ;;
 
   * )
@@ -44,4 +44,4 @@ case "$COMMAND" in
     ;;
 esac
 
-exec "$@"
+exec /sbin/tini -- "$@"


### PR DESCRIPTION
I noticed the container took some time to stop, likely reaching the stopping grace period which often results in a `SIGKILL` signal. This is because Docker sends signals to `PID 1` and in that case it was the entrypoint script.

While the image could be somewhat refactored to avoid that, a common fix to this issue is using `tini` which ensures that `SIGTERM` is propagated to all subprocesses so they can gracefully stop.

The container now stops almost instantaneously and gracefully as shown by logs:

```
- Gracefully stopping, waiting for requests to finish
=== puma shutdown: 2020-08-26 13:15:40 +0000 ===
- Goodbye!
Exiting
```