### PR TITLE
feat: make async the default active job queue adapter

### DIFF
--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -135,9 +135,7 @@ class Api::AuthController < Api::ApiController
     user.updated_with_user_agent = request.user_agent
     user.save
 
-    if ENV['AWS_REGION']
-      RegistrationJob.perform_later(user.email, user.created_at.to_s)
-    end
+    RegistrationJob.perform_later(user.email, user.created_at.to_s)
 
     render json: result
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ module SyncingServer
     config.active_record.primary_key = :uuid
 
     Shoryuken.logger.level = Logger::INFO
-    config.active_job.queue_adapter = :shoryuken
+    config.active_job.queue_adapter = ENV.has_key?('ACTIVE_JOB_QUEUE_ADAPTER') ? ENV['ACTIVE_JOB_QUEUE_ADAPTER'].to_sym : :async
     config.action_mailer.deliver_later_queue_name = ENV['SQS_QUEUE'] || 'dev_queue'
 
     # Cross-Origin Resource Sharing (CORS) for Rack compatible web applications.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,7 +52,6 @@ Rails.application.configure do
   config.assets.logger = false
   config.assets.quiet = true
 
-  config.active_job.queue_adapter = :inline
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
 

--- a/config/shoryuken.yml
+++ b/config/shoryuken.yml
@@ -1,3 +1,3 @@
 aws:
-  region: us-east-1
+  region: <%= ENV.fetch('AWS_REGION', 'us-east-1') %>
 concurrency: <%= ENV.fetch('DB_POOL_SIZE', 5) %>

--- a/env.sample
+++ b/env.sample
@@ -13,6 +13,8 @@ RAILS_LOG_TO_STDOUT=false
 #SQS_QUEUE=somequeue
 #AWS_REGION=us-west1
 
+ACTIVE_JOB_QUEUE_ADAPTER=async
+
 # Database Settings
 DB_PORT=3306
 DB_HOST=127.0.0.1


### PR DESCRIPTION
Rails 5 Active Job default adapter is `:async`: https://blog.bigbinary.com/2016/03/29/rails-5-changed-default-active-job-adapter-to-async.html

This change fixes the issue where someone would have to have `AWS_REGION` environment variable set in order to have the queue processed in `RAILS_ENV=production`. This was due to the fact that `shoryuken` was the default queue adapter.