### PR TITLE
feat: key params with additional authenticated values

### DIFF
--- a/app/jobs/extension_job.rb
+++ b/app/jobs/extension_job.rb
@@ -13,7 +13,7 @@ class ExtensionJob < ApplicationJob
       user.items.where(deleted: false).to_a
     end
 
-    auth_params = user.auth_params
+    auth_params = user.key_params
 
     settings = ExtensionSetting.find_or_create_by(extension_id: extension_id)
     mute_emails = force_mute || settings.mute_emails

--- a/app/mailers/archive_mailer.rb
+++ b/app/mailers/archive_mailer.rb
@@ -6,7 +6,7 @@ class ArchiveMailer < ApplicationMailer
     date = Date.today
     data = {
       items: user.items.where(deleted: false),
-      auth_params: user.auth_params,
+      auth_params: user.key_params,
     }
     attachments["SN-Data-#{date}.txt"] = {
       mime_type: 'application/json',

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,7 @@ class User < ApplicationRecord
       params[:pw_nonce] = pw_nonce
     when '003'
       params[:pw_nonce] = pw_nonce
+      params[:pw_cost] = pw_cost
     when '002'
       params[:email] = email
       params[:pw_cost] = pw_cost

--- a/config/sn_session.yml
+++ b/config/sn_session.yml
@@ -4,8 +4,8 @@ default: &default
 
 development:
   <<: *default
-  access_token_age: <%= 2.seconds %>
-  refresh_token_age: <%= 6.seconds %>
+  access_token_age: <%= 50.seconds %>
+  refresh_token_age: <%= 100.seconds %>
 
 test:
   <<: *default

--- a/config/sn_session.yml
+++ b/config/sn_session.yml
@@ -4,8 +4,8 @@ default: &default
 
 development:
   <<: *default
-  access_token_age: <%= 50.seconds %>
-  refresh_token_age: <%= 100.seconds %>
+  access_token_age: <%= 5.minutes %>
+  refresh_token_age: <%= 10.minutes %>
 
 test:
   <<: *default

--- a/db/migrate/20200916205444_add_key_param_fields.rb
+++ b/db/migrate/20200916205444_add_key_param_fields.rb
@@ -1,0 +1,6 @@
+class AddKeyParamFields < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :kp_origination, :string, optional: true, after: :version
+    add_column :users, :kp_created, :string, optional: true, after: :kp_origination
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200913150251) do
+ActiveRecord::Schema.define(version: 20200916205444) do
 
   create_table "extension_settings", primary_key: "uuid", id: :string, limit: 36, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "extension_id"
@@ -86,6 +86,8 @@ ActiveRecord::Schema.define(version: 20200913150251) do
     t.datetime "updated_at"
     t.string "pw_salt"
     t.string "version"
+    t.string "kp_origination"
+    t.string "kp_created"
     t.text "updated_with_user_agent"
     t.datetime "locked_until"
     t.integer "num_failed_attempts"

--- a/env.sample
+++ b/env.sample
@@ -32,6 +32,7 @@ DB_WAIT_TIMEOUT=180
 # To generate required secret key base below
 
 SECRET_KEY_BASE=changeme123
+PSEUDO_KEY_PARAMS_KEY=changeme456
 
 # Disable user registration
 #DISABLE_USER_REGISTRATION=true

--- a/lib/sync_engine/2020_01_15/user_manager.rb
+++ b/lib/sync_engine/2020_01_15/user_manager.rb
@@ -15,6 +15,7 @@ module SyncEngine
 
         return {
           session: session&.as_client_payload,
+          key_params: user.key_params(true),
           user: user,
         }
       end
@@ -39,6 +40,7 @@ module SyncEngine
 
         return {
           session: session.as_client_payload,
+          key_params: user.key_params(true),
           user: user,
         }
       end

--- a/lib/sync_engine/abstract/user_manager.rb
+++ b/lib/sync_engine/abstract/user_manager.rb
@@ -40,30 +40,6 @@ module SyncEngine
       return success_auth_response(user, params)
     end
 
-    def auth_params(email)
-      user = @user_class.find_by_email(email)
-      return nil unless user
-
-      auth_params = {
-        identifier: user.email,
-        pw_cost: user.pw_cost,
-        pw_nonce: user.pw_nonce,
-        version: user.version,
-      }
-
-      if user.version == '002'
-        auth_params[:pw_salt] = user.pw_salt
-      end
-
-      if user.version == '001'
-        auth_params[:pw_func] = user.pw_func
-        auth_params[:pw_alg] = user.pw_alg
-        auth_params[:pw_key_size] = user.pw_key_size
-      end
-
-      return auth_params
-    end
-
     private
 
     def success_auth_response(_user, _params)
@@ -78,6 +54,8 @@ module SyncEngine
         :pw_key_size,
         :pw_nonce,
         :pw_salt,
+        :origination,
+        :created,
         :version
       )
     end

--- a/spec/controllers/api/auth_controller_spec.rb
+++ b/spec/controllers/api/auth_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Api::AuthController, type: :controller do
   end
 
   let(:auth_params_keys_003) do
-    %w[identifier pw_nonce version].sort
+    %w[identifier pw_nonce version pw_cost].sort
   end
 
   let(:auth_params_keys_004) do
@@ -76,7 +76,7 @@ RSpec.describe Api::AuthController, type: :controller do
 
         parsed_response_body = JSON.parse(response.body)
 
-        expect(parsed_response_body.keys.sort).to contain_exactly(*auth_params_keys_003)
+        expect(parsed_response_body.keys.sort).to contain_exactly(*auth_params_keys_004)
         expect(parsed_response_body['identifier']).to eq test_user_004.email
         expect(parsed_response_body['version']).to_not be_nil
         expect(parsed_response_body['origination']).to be_nil

--- a/spec/controllers/api/auth_controller_spec.rb
+++ b/spec/controllers/api/auth_controller_spec.rb
@@ -20,11 +20,15 @@ RSpec.describe Api::AuthController, type: :controller do
   end
 
   let(:auth_params_keys_003) do
-    %w[identifier pw_cost pw_nonce version].sort
+    %w[identifier pw_nonce version].sort
   end
 
   let(:auth_params_keys_004) do
     %w[identifier pw_nonce version].sort
+  end
+
+  let(:auth_params_authenticated_keys_004) do
+    %w[identifier pw_nonce version origination created].sort
   end
 
   let(:mfa_item) do
@@ -62,10 +66,40 @@ RSpec.describe Api::AuthController, type: :controller do
         expect(parsed_response_body['version']).to_not be_nil
       end
     end
+
+    context 'when the provided email belongs to a 004 user' do
+      it 'should not return origination and created with no session' do
+        get :auth_params, params: { email: test_user_004.email }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
+
+        parsed_response_body = JSON.parse(response.body)
+
+        expect(parsed_response_body.keys.sort).to contain_exactly(*auth_params_keys_003)
+        expect(parsed_response_body['identifier']).to eq test_user_004.email
+        expect(parsed_response_body['version']).to_not be_nil
+        expect(parsed_response_body['origination']).to be_nil
+        expect(parsed_response_body['created']).to be_nil
+      end
+
+      it 'should return origination and created with session' do
+        post :sign_in, params: test_user_004_credentials
+        access_token = JSON.parse(response.body)['session']['access_token']
+        request.headers['Authorization'] = "bearer #{access_token}"
+
+        get :auth_params, params: { email: test_user_004.email }
+
+        parsed_response_body = JSON.parse(response.body)
+
+        expect(parsed_response_body['origination']).to_not be_nil
+        expect(parsed_response_body['created']).to_not be_nil
+      end
+    end
   end
 
   describe 'POST auth/sign_in' do
-    context 'when no crendentials are provided' do
+    context 'when no credentials are provided' do
       it 'sign in should fail' do
         post :sign_in
 
@@ -79,7 +113,7 @@ RSpec.describe Api::AuthController, type: :controller do
       end
     end
 
-    context 'when invalid crendentials are provided' do
+    context 'when invalid credentials are provided' do
       it 'sign in should fail' do
         post :sign_in, params: { email: test_user.email, password: 'invalid-password' }
 
@@ -93,7 +127,7 @@ RSpec.describe Api::AuthController, type: :controller do
       end
     end
 
-    context 'when invalid crendentials are provided multiple times' do
+    context 'when invalid credentials are provided multiple times' do
       it 'sign in should fail and user should be locked' do
         [*1..6].each do |_login_attempt|
           post :sign_in, params: { email: test_user.email, password: 'invalid-password' }
@@ -122,7 +156,7 @@ RSpec.describe Api::AuthController, type: :controller do
       end
     end
 
-    context 'when valid crendentials are provided' do
+    context 'when valid credentials are provided' do
       it 'sign in should not fail' do
         post :sign_in, params: test_user_003_credentials
 
@@ -134,6 +168,16 @@ RSpec.describe Api::AuthController, type: :controller do
         expect(parsed_response_body['user']).to_not be_nil
         expect(parsed_response_body['user']['email']).to eq(test_user_003_credentials[:email])
         expect(parsed_response_body['token']).to_not be_nil
+      end
+
+      it 'sign in should return full key params' do
+        post :sign_in, params: test_user_004_credentials
+
+        parsed_response_body = JSON.parse(response.body)
+
+        expect(parsed_response_body['key_params']).to_not be_nil
+        expect(parsed_response_body['key_params']['origination']).to_not be_nil
+        expect(parsed_response_body['key_params']['created']).to_not be_nil
       end
     end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -17,11 +17,16 @@ FactoryBot.define do
         user_manager = SyncEngine::V20161215::UserManager.new(User)
         '20161215'
       end
-
-      params = ActionController::Parameters.new(pw_cost: 110_000, api: api_version, version: version)
+      params = ActionController::Parameters.new(
+        api: api_version,
+        version: version,
+        kp_origination: 'registration',
+        kp_created: DateTime.now.to_i
+      )
       result = user_manager.register(email, password, params)
 
       result[:user]
     end
   end
+
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -20,8 +20,8 @@ FactoryBot.define do
       params = ActionController::Parameters.new(
         api: api_version,
         version: version,
-        kp_origination: 'registration',
-        kp_created: DateTime.now.to_i
+        origination: 'registration',
+        created: DateTime.now.to_i.to_s
       )
       result = user_manager.register(email, password, params)
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe User, type: :model do
       subject.version = '003'
 
       auth_params = subject.key_params
-      expect(auth_params.keys.sort).to contain_exactly(:identifier, :pw_nonce, :version)
+      expect(auth_params.keys.sort).to contain_exactly(:identifier, :pw_nonce, :version, :pw_cost)
     end
 
     specify do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,19 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   subject do
-    described_class.create(pw_cost: 11_000, version: '003', email: 'sn@testing.com', encrypted_password: 'encrypted')
+    described_class.create(
+      pw_nonce: 'somenonce',
+      version: '004',
+      email: 'sn@testing.com',
+      encrypted_password: 'encrypted',
+      kp_origination: 'registration',
+      kp_created: DateTime.now.to_i,
+      pw_salt: 'salt',
+      pw_cost: 1,
+      pw_alg: 'alg',
+      pw_func: 'func',
+      pw_key_size: 1
+    )
   end
 
   describe 'serializable_hash' do
@@ -22,29 +34,34 @@ RSpec.describe User, type: :model do
 
   describe 'auth_params' do
     specify do
-      auth_params = subject.auth_params
-      expect(auth_params.keys).to contain_exactly(:pw_cost, :version, :identifier)
+      auth_params = subject.key_params
+      expect(auth_params.keys.sort).to contain_exactly(:identifier, :pw_nonce, :version)
     end
 
     specify do
-      subject.pw_nonce = 'some nonce'
-
-      auth_params = subject.auth_params
-      expect(auth_params.keys).to contain_exactly(:pw_cost, :version, :identifier, :pw_nonce)
+      auth_params = subject.key_params(true)
+      expect(auth_params.keys.sort).to contain_exactly(:identifier, :created, :origination, :pw_nonce, :version)
     end
 
     specify do
-      subject.pw_salt = 'some salt'
+      subject.version = '003'
 
-      auth_params = subject.auth_params
-      expect(auth_params.keys).to contain_exactly(:pw_cost, :version, :identifier, :pw_salt)
+      auth_params = subject.key_params
+      expect(auth_params.keys.sort).to contain_exactly(:identifier, :pw_nonce, :version)
     end
 
     specify do
-      subject.pw_func = 'some function'
+      subject.version = '002'
 
-      auth_params = subject.auth_params
-      expect(auth_params.keys).to contain_exactly(:pw_cost, :version, :identifier, :pw_func, :pw_alg, :pw_key_size)
+      auth_params = subject.key_params
+      expect(auth_params.keys.sort).to contain_exactly(:email, :identifier, :pw_cost, :pw_salt, :version)
+    end
+
+    specify do
+      subject.version = '001'
+
+      auth_params = subject.key_params
+      expect(auth_params.keys.sort).to contain_exactly(:email, :identifier, :pw_alg, :pw_cost, :pw_func, :pw_key_size, :pw_salt, :version)
     end
   end
 


### PR DESCRIPTION
- Renames auth params to key params
- If accessing key params endpoint with valid session, returns additional data, including the origination of the key params (registration, password-change, etc) and a created timestamp in string format (number of seconds since epoch)
- Introduces new ENV variable `PSEUDO_KEY_PARAMS_KEY` to use for pseudo params instead of `Rails.application.secrets.secret_key_base`