### PR TITLE
feat: set a value for items_key_id and auth_hash if not provided in a request

### DIFF
--- a/lib/sync_engine/2016_12_15/sync_manager.rb
+++ b/lib/sync_engine/2016_12_15/sync_manager.rb
@@ -4,7 +4,7 @@ module SyncEngine
       def sync(item_hashes, options, request)
         in_sync_token = options[:sync_token]
         in_cursor_token = options[:cursor_token]
-        limit = options[:limit]
+        limit = options[:limit].to_i
         content_type = options[:content_type] # optional, only return items of these type if present
 
         retrieved_items, cursor_token = _sync_get(in_sync_token, in_cursor_token, limit, content_type).to_a
@@ -81,7 +81,7 @@ module SyncEngine
           end
 
           item.last_user_agent = request.user_agent
-          item.update(item_hash.permit(*permitted_params))
+          item.update(item_params(item_hash))
 
           if item.deleted == true
             item.mark_as_deleted

--- a/lib/sync_engine/2019_05_20/sync_manager.rb
+++ b/lib/sync_engine/2019_05_20/sync_manager.rb
@@ -92,7 +92,7 @@ module SyncEngine
           end
 
           if !item
-            item = @user.items.new({ uuid: item_hash[:uuid] }.merge(item_hash.permit(*permitted_params)))
+            item = @user.items.new({ uuid: item_hash[:uuid] }.merge(item_params(item_hash)))
             item.last_user_agent = request.user_agent
             begin
               item.save
@@ -105,7 +105,7 @@ module SyncEngine
             end
           else
             item.last_user_agent = request.user_agent
-            item.update(item_hash.permit(*permitted_params))
+            item.update(item_params(item_hash))
           end
 
           if item.deleted == true

--- a/lib/sync_engine/abstract/sync_manager.rb
+++ b/lib/sync_engine/abstract/sync_manager.rb
@@ -38,8 +38,12 @@ module SyncEngine
       date
     end
 
-    def item_params
-      params.permit(*permitted_params)
+    def item_params(params)
+      defaults = {
+        items_key_id: nil,
+        auth_hash: nil,
+      }
+      params.permit(*permitted_params).reverse_merge(defaults)
     end
 
     def permitted_params

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -116,6 +116,7 @@ RSpec.describe Api::ItemsController, type: :controller do
             items_param = serialize_to_hash(items_param)
             expect(saved_items).to match_array(items_param)
           end
+
           it 'should store revisions matching changes' do
             @controller = Api::AuthController.new
             post :sign_in, params: test_user_003_credentials
@@ -382,24 +383,92 @@ RSpec.describe Api::ItemsController, type: :controller do
       end
 
       context 'when using the fallback api' do
-        it 'should return results' do
-          @controller = Api::AuthController.new
-          post :sign_in, params: test_user_003_credentials
+        context 'and a sync request is sent' do
+          it 'should return results' do
+            @controller = Api::AuthController.new
+            post :sign_in, params: test_user_003_credentials
 
-          @controller = Api::ItemsController.new
-          request.headers['Authorization'] = "bearer #{JSON.parse(response.body)['token']}"
-          post :sync, params: { sync_token: '', cursor_token: '', limit: 5, items: [test_items] }
+            @controller = Api::ItemsController.new
+            request.headers['Authorization'] = "bearer #{JSON.parse(response.body)['token']}"
+            post :sync, params: { sync_token: '', cursor_token: '', limit: 5, items: [test_items] }
 
-          expect(response).to have_http_status(:ok)
-          expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
+            expect(response).to have_http_status(:ok)
+            expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
 
-          parsed_response_body = JSON.parse(response.body)
+            parsed_response_body = JSON.parse(response.body)
 
-          expect(parsed_response_body).to_not be_nil
-          expect(parsed_response_body['retrieved_items']).to_not be_nil
-          expect(parsed_response_body['saved_items']).to_not be_nil
-          expect(parsed_response_body['sync_token']).to_not be_nil
-          expect(parsed_response_body).to have_key('cursor_token')
+            expect(parsed_response_body).to_not be_nil
+            expect(parsed_response_body['retrieved_items']).to_not be_nil
+            expect(parsed_response_body['saved_items']).to_not be_nil
+            expect(parsed_response_body['sync_token']).to_not be_nil
+            expect(parsed_response_body).to have_key('cursor_token')
+          end
+        end
+
+        context 'and syncing items without the items_key_id field' do
+          it 'should set a default value for the field' do
+            @controller = Api::AuthController.new
+            post :sign_in, params: test_user_003_credentials
+
+            @controller = Api::ItemsController.new
+            request.headers['Authorization'] = "bearer #{JSON.parse(response.body)['token']}"
+
+            new_item = create(:item, :with_items_key_id, user_uuid: test_user.uuid)
+
+            items_param = [new_item].to_a.map(&:serializable_hash)
+            items_param[0].delete('items_key_id')
+
+            post :sync, params: { limit: 5, items: items_param }
+
+            expect(response).to have_http_status(:ok)
+            expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
+
+            parsed_response_body = JSON.parse(response.body)
+
+            expect(parsed_response_body).to_not be_nil
+
+            saved_items = parsed_response_body['saved_items']
+            expect(saved_items).to_not be_nil
+
+            saved_item = serialize_to_hash(saved_items)[0]
+            actual_item = Item.find(new_item[:uuid])
+
+            expect(saved_item[:items_key_id]).to be_nil
+            expect(actual_item[:items_key_id]).to be_nil
+          end
+        end
+
+        context 'and syncing items without the auth_hash field' do
+          it 'should set a default value for the field' do
+            @controller = Api::AuthController.new
+            post :sign_in, params: test_user_003_credentials
+
+            @controller = Api::ItemsController.new
+            request.headers['Authorization'] = "bearer #{JSON.parse(response.body)['token']}"
+
+            new_item = create(:item, :with_auth_hash, user_uuid: test_user.uuid)
+
+            items_param = [new_item].to_a.map(&:serializable_hash)
+            items_param[0].delete('auth_hash')
+
+            post :sync, params: { limit: 5, items: items_param }
+
+            expect(response).to have_http_status(:ok)
+            expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
+
+            parsed_response_body = JSON.parse(response.body)
+
+            expect(parsed_response_body).to_not be_nil
+
+            saved_items = parsed_response_body['saved_items']
+            expect(saved_items).to_not be_nil
+
+            saved_item = serialize_to_hash(saved_items)[0]
+            actual_item = Item.find(new_item[:uuid])
+
+            expect(saved_item[:auth_hash]).to be_nil
+            expect(actual_item[:auth_hash]).to be_nil
+          end
         end
       end
 

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -256,22 +256,15 @@ RSpec.describe Api::ItemsController, type: :controller do
             request.headers['Authorization'] = "bearer #{JSON.parse(response.body)['token']}"
 
             new_item = create(:item, :with_items_key_id, user_uuid: test_user.uuid)
+            expect(new_item.items_key_id).to_not be_nil
 
             items_param = [new_item].to_a.map(&:serializable_hash)
             items_param[0].delete('items_key_id')
 
             post :sync, params: { limit: 5, api: '20190520', items: items_param }
 
-            expect(response).to have_http_status(:ok)
-            expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
-
             parsed_response_body = JSON.parse(response.body)
-
-            expect(parsed_response_body).to_not be_nil
-
             saved_items = parsed_response_body['saved_items']
-            expect(saved_items).to_not be_nil
-
             saved_item = serialize_to_hash(saved_items)[0]
             actual_item = Item.find(new_item[:uuid])
 
@@ -289,22 +282,15 @@ RSpec.describe Api::ItemsController, type: :controller do
             request.headers['Authorization'] = "bearer #{JSON.parse(response.body)['token']}"
 
             new_item = create(:item, :with_auth_hash, user_uuid: test_user.uuid)
+            expect(new_item.auth_hash).to_not be_nil
 
             items_param = [new_item].to_a.map(&:serializable_hash)
             items_param[0].delete('auth_hash')
 
             post :sync, params: { limit: 5, api: '20190520', items: items_param }
 
-            expect(response).to have_http_status(:ok)
-            expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
-
             parsed_response_body = JSON.parse(response.body)
-
-            expect(parsed_response_body).to_not be_nil
-
             saved_items = parsed_response_body['saved_items']
-            expect(saved_items).to_not be_nil
-
             saved_item = serialize_to_hash(saved_items)[0]
             actual_item = Item.find(new_item[:uuid])
 
@@ -419,9 +405,6 @@ RSpec.describe Api::ItemsController, type: :controller do
             items_param[0].delete('items_key_id')
 
             post :sync, params: { limit: 5, items: items_param }
-
-            expect(response).to have_http_status(:ok)
-            expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
 
             parsed_response_body = JSON.parse(response.body)
 

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -245,6 +245,140 @@ RSpec.describe Api::ItemsController, type: :controller do
             expect(saved_items[3]).to match(items_param[3])
           end
         end
+
+        context 'and syncing items without the items_key_id field' do
+          it 'should set a default value for the field' do
+            @controller = Api::AuthController.new
+            post :sign_in, params: test_user_003_credentials
+
+            @controller = Api::ItemsController.new
+            request.headers['Authorization'] = "bearer #{JSON.parse(response.body)['token']}"
+
+            new_item = create(:item, :with_items_key_id, user_uuid: test_user.uuid)
+
+            items_param = [new_item].to_a.map(&:serializable_hash)
+            items_param[0].delete('items_key_id')
+
+            post :sync, params: { limit: 5, api: '20190520', items: items_param }
+
+            expect(response).to have_http_status(:ok)
+            expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
+
+            parsed_response_body = JSON.parse(response.body)
+
+            expect(parsed_response_body).to_not be_nil
+
+            saved_items = parsed_response_body['saved_items']
+            expect(saved_items).to_not be_nil
+
+            saved_item = serialize_to_hash(saved_items)[0]
+            actual_item = Item.find(new_item[:uuid])
+
+            expect(saved_item[:items_key_id]).to be_nil
+            expect(actual_item[:items_key_id]).to be_nil
+          end
+        end
+
+        context 'and syncing items without the auth_hash field' do
+          it 'should set a default value for the field' do
+            @controller = Api::AuthController.new
+            post :sign_in, params: test_user_003_credentials
+
+            @controller = Api::ItemsController.new
+            request.headers['Authorization'] = "bearer #{JSON.parse(response.body)['token']}"
+
+            new_item = create(:item, :with_auth_hash, user_uuid: test_user.uuid)
+
+            items_param = [new_item].to_a.map(&:serializable_hash)
+            items_param[0].delete('auth_hash')
+
+            post :sync, params: { limit: 5, api: '20190520', items: items_param }
+
+            expect(response).to have_http_status(:ok)
+            expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
+
+            parsed_response_body = JSON.parse(response.body)
+
+            expect(parsed_response_body).to_not be_nil
+
+            saved_items = parsed_response_body['saved_items']
+            expect(saved_items).to_not be_nil
+
+            saved_item = serialize_to_hash(saved_items)[0]
+            actual_item = Item.find(new_item[:uuid])
+
+            expect(saved_item[:auth_hash]).to be_nil
+            expect(actual_item[:auth_hash]).to be_nil
+          end
+        end
+      end
+
+      context 'when using the 20200115 api' do
+        context 'and syncing items without the items_key_id field' do
+          it 'should set a default value for the field' do
+            @controller = Api::AuthController.new
+            post :sign_in, params: test_user_003_credentials
+
+            @controller = Api::ItemsController.new
+            request.headers['Authorization'] = "bearer #{JSON.parse(response.body)['token']}"
+
+            new_item = create(:item, :with_items_key_id, user_uuid: test_user.uuid)
+
+            items_param = [new_item].to_a.map(&:serializable_hash)
+            items_param[0].delete('items_key_id')
+
+            post :sync, params: { limit: 5, api: '20200115', items: items_param }
+
+            expect(response).to have_http_status(:ok)
+            expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
+
+            parsed_response_body = JSON.parse(response.body)
+
+            expect(parsed_response_body).to_not be_nil
+
+            saved_items = parsed_response_body['saved_items']
+            expect(saved_items).to_not be_nil
+
+            saved_item = serialize_to_hash(saved_items)[0]
+            actual_item = Item.find(new_item[:uuid])
+
+            expect(saved_item[:items_key_id]).to be_nil
+            expect(actual_item[:items_key_id]).to be_nil
+          end
+        end
+
+        context 'and syncing items without the auth_hash field' do
+          it 'should set a default value for the field' do
+            @controller = Api::AuthController.new
+            post :sign_in, params: test_user_003_credentials
+
+            @controller = Api::ItemsController.new
+            request.headers['Authorization'] = "bearer #{JSON.parse(response.body)['token']}"
+
+            new_item = create(:item, :with_auth_hash, user_uuid: test_user.uuid)
+
+            items_param = [new_item].to_a.map(&:serializable_hash)
+            items_param[0].delete('auth_hash')
+
+            post :sync, params: { limit: 5, api: '20200115', items: items_param }
+
+            expect(response).to have_http_status(:ok)
+            expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
+
+            parsed_response_body = JSON.parse(response.body)
+
+            expect(parsed_response_body).to_not be_nil
+
+            saved_items = parsed_response_body['saved_items']
+            expect(saved_items).to_not be_nil
+
+            saved_item = serialize_to_hash(saved_items)[0]
+            actual_item = Item.find(new_item[:uuid])
+
+            expect(saved_item[:auth_hash]).to be_nil
+            expect(actual_item[:auth_hash]).to be_nil
+          end
+        end
       end
 
       context 'when using the fallback api' do

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -310,22 +310,15 @@ RSpec.describe Api::ItemsController, type: :controller do
             request.headers['Authorization'] = "bearer #{JSON.parse(response.body)['token']}"
 
             new_item = create(:item, :with_items_key_id, user_uuid: test_user.uuid)
+            expect(new_item.items_key_id).to_not be_nil
 
             items_param = [new_item].to_a.map(&:serializable_hash)
             items_param[0].delete('items_key_id')
 
             post :sync, params: { limit: 5, api: '20200115', items: items_param }
 
-            expect(response).to have_http_status(:ok)
-            expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
-
             parsed_response_body = JSON.parse(response.body)
-
-            expect(parsed_response_body).to_not be_nil
-
             saved_items = parsed_response_body['saved_items']
-            expect(saved_items).to_not be_nil
-
             saved_item = serialize_to_hash(saved_items)[0]
             actual_item = Item.find(new_item[:uuid])
 
@@ -343,22 +336,15 @@ RSpec.describe Api::ItemsController, type: :controller do
             request.headers['Authorization'] = "bearer #{JSON.parse(response.body)['token']}"
 
             new_item = create(:item, :with_auth_hash, user_uuid: test_user.uuid)
+            expect(new_item.auth_hash).to_not be_nil
 
             items_param = [new_item].to_a.map(&:serializable_hash)
             items_param[0].delete('auth_hash')
 
             post :sync, params: { limit: 5, api: '20200115', items: items_param }
 
-            expect(response).to have_http_status(:ok)
-            expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
-
             parsed_response_body = JSON.parse(response.body)
-
-            expect(parsed_response_body).to_not be_nil
-
             saved_items = parsed_response_body['saved_items']
-            expect(saved_items).to_not be_nil
-
             saved_item = serialize_to_hash(saved_items)[0]
             actual_item = Item.find(new_item[:uuid])
 
@@ -400,6 +386,7 @@ RSpec.describe Api::ItemsController, type: :controller do
             request.headers['Authorization'] = "bearer #{JSON.parse(response.body)['token']}"
 
             new_item = create(:item, :with_items_key_id, user_uuid: test_user.uuid)
+            expect(new_item.items_key_id).to_not be_nil
 
             items_param = [new_item].to_a.map(&:serializable_hash)
             items_param[0].delete('items_key_id')
@@ -407,12 +394,7 @@ RSpec.describe Api::ItemsController, type: :controller do
             post :sync, params: { limit: 5, items: items_param }
 
             parsed_response_body = JSON.parse(response.body)
-
-            expect(parsed_response_body).to_not be_nil
-
             saved_items = parsed_response_body['saved_items']
-            expect(saved_items).to_not be_nil
-
             saved_item = serialize_to_hash(saved_items)[0]
             actual_item = Item.find(new_item[:uuid])
 
@@ -430,22 +412,15 @@ RSpec.describe Api::ItemsController, type: :controller do
             request.headers['Authorization'] = "bearer #{JSON.parse(response.body)['token']}"
 
             new_item = create(:item, :with_auth_hash, user_uuid: test_user.uuid)
+            expect(new_item.auth_hash).to_not be_nil
 
             items_param = [new_item].to_a.map(&:serializable_hash)
             items_param[0].delete('auth_hash')
 
             post :sync, params: { limit: 5, items: items_param }
 
-            expect(response).to have_http_status(:ok)
-            expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
-
             parsed_response_body = JSON.parse(response.body)
-
-            expect(parsed_response_body).to_not be_nil
-
             saved_items = parsed_response_body['saved_items']
-            expect(saved_items).to_not be_nil
-
             saved_item = serialize_to_hash(saved_items)[0]
             actual_item = Item.find(new_item[:uuid])
 

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -28,5 +28,13 @@ FactoryBot.define do
       content { encode_content(frequency: 'realtime', url: 'http://test.com') }
       content_type { 'SF|Extension' }
     end
+
+    trait :with_items_key_id do
+      items_key_id { SecureRandom.uuid }
+    end
+
+    trait :with_auth_hash do
+      auth_hash { '003:something' }
+    end
   end
 end


### PR DESCRIPTION
In new and old API versions, always save `items_key_id` and `auth_hash` field values, even if they're not present.

- [x] test for api version `20161215`
- [x] test for api version `20190520`
- [x] test for api version `20200115`