### PR TITLE
Add support for using database read replicas

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -27,6 +27,9 @@ DB_PASSWORD=changeme123
 DB_POOL_SIZE=30
 DB_WAIT_TIMEOUT=180
 
+# (Optional) Database Replication
+#DB_REPLICA_HOST=
+
 # Secrets
 # Use: "bundle exec rake secret" or "openssl rand -hex 64"
 # To generate required secret key base below

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -2,7 +2,7 @@ name: Dev
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ develop, db_read_replica ]
 
 jobs:
   test:
@@ -10,7 +10,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:5.6
         env:
           MYSQL_ROOT_PASSWORD: "changeme123"
           MYSQL_DATABASE: "standard_notes_db"

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -2,7 +2,7 @@ name: Dev
 
 on:
   push:
-    branches: [ develop, db_read_replica ]
+    branches: [ develop ]
 
 jobs:
   test:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:5.6
         env:
           MYSQL_ROOT_PASSWORD: "changeme123"
           MYSQL_DATABASE: "standard_notes_db"

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -10,7 +10,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:5.6
         env:
           MYSQL_ROOT_PASSWORD: "changeme123"
           MYSQL_DATABASE: "standard_notes_db"

--- a/Gemfile
+++ b/Gemfile
@@ -41,3 +41,7 @@ gem "lograge", "~> 0.11.2"
 gem "aws-sdk-s3", "~> 1.64"
 
 gem 'bootsnap', '~> 1.4'
+
+gem "makara", "~> 0.4.1"
+
+gem "distribute_reads", "~> 0.3.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
       msgpack
     device_detector (1.0.5)
     diff-lcs (1.4.4)
+    distribute_reads (0.3.3)
+      makara (>= 0.3)
     docile (1.3.2)
     dogstatsd-ruby (4.8.1)
     dotenv (2.7.6)
@@ -123,6 +125,8 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
+    makara (0.4.1)
+      activerecord (>= 3.0.0)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
@@ -250,6 +254,7 @@ DEPENDENCIES
   byebug
   ddtrace (~> 0.40)
   device_detector
+  distribute_reads (~> 0.3.3)
   dogstatsd-ruby (~> 4.8)
   dotenv-rails
   factory_bot_rails
@@ -257,6 +262,7 @@ DEPENDENCIES
   jwt
   listen
   lograge (~> 0.11.2)
+  makara (~> 0.4.1)
   mysql2 (>= 0.3.13, < 0.5)
   puma
   rack-cors

--- a/app/jobs/cleanup_revisions_job.rb
+++ b/app/jobs/cleanup_revisions_job.rb
@@ -5,29 +5,31 @@ class CleanupRevisionsJob < ApplicationJob
   MIN_REVISIONS_PER_DAY = 2
 
   def perform(item_id, days)
-    item = Item.find_by_uuid(item_id)
+    distribute_reads do
+      item = Item.find_by_uuid(item_id)
 
-    unless item
-      Rails.logger.warn "Could not find item with uuid #{item_id}"
+      unless item
+        Rails.logger.warn "Could not find item with uuid #{item_id}"
 
-      return
-    end
+        return
+      end
 
-    last_days_of_revisions = item.revisions
-      .select(:creation_date)
-      .order(creation_date: :desc)
-      .group(:creation_date)
-      .take(days)
+      last_days_of_revisions = item.revisions
+        .select(:creation_date)
+        .order(creation_date: :desc)
+        .group(:creation_date)
+        .take(days)
 
-    days_to_process = []
-    last_days_of_revisions.each do |revision|
-      days_to_process.push(revision.creation_date)
-    end
+      days_to_process = []
+      last_days_of_revisions.each do |revision|
+        days_to_process.push(revision.creation_date)
+      end
 
-    days_to_process.each do |day|
-      days_from_today = (DateTime.now - day).to_i
-      allowed_revisions_count = [[days - days_from_today, MAX_REVISIONS_PER_DAY].min, MIN_REVISIONS_PER_DAY].max
-      cleanup_revisions_for_a_day(item, days_from_today, allowed_revisions_count)
+      days_to_process.each do |day|
+        days_from_today = (DateTime.now - day).to_i
+        allowed_revisions_count = [[days - days_from_today, MAX_REVISIONS_PER_DAY].min, MIN_REVISIONS_PER_DAY].max
+        cleanup_revisions_for_a_day(item, days_from_today, allowed_revisions_count)
+      end
     end
   rescue StandardError => e
     Rails.logger.error "Could not cleanup revisions for item #{item_id}: #{e.message}"

--- a/app/jobs/duplicate_revisions_job.rb
+++ b/app/jobs/duplicate_revisions_job.rb
@@ -2,25 +2,27 @@ class DuplicateRevisionsJob < ApplicationJob
   queue_as ENV['SQS_QUEUE_LOW_PRIORITY'] || 'sn_main_low_priority'
 
   def perform(item_id)
-    item = Item.find_by_uuid(item_id)
+    distribute_reads do
+      item = Item.find_by_uuid(item_id)
 
-    unless item
-      Rails.logger.warn "Could not find item with uuid #{item_id}"
+      unless item
+        Rails.logger.warn "Could not find item with uuid #{item_id}"
 
-      return
-    end
+        return
+      end
 
-    existing_original_item = Item
-      .where(uuid: item.duplicate_of, user_uuid: item.user_uuid)
-      .first
+      existing_original_item = Item
+        .where(uuid: item.duplicate_of, user_uuid: item.user_uuid)
+        .first
 
-    if existing_original_item
-      original_item_revisions = existing_original_item
-        .item_revisions
-        .pluck(:revision_uuid)
+      if existing_original_item
+        original_item_revisions = existing_original_item
+          .item_revisions
+          .pluck(:revision_uuid)
 
-      original_item_revisions.each do |revision_uuid|
-        ItemRevision.create(item_uuid: item_id, revision_uuid: revision_uuid)
+        original_item_revisions.each do |revision_uuid|
+          ItemRevision.create(item_uuid: item_id, revision_uuid: revision_uuid)
+        end
       end
     end
   rescue StandardError => e

--- a/app/jobs/extension_job.rb
+++ b/app/jobs/extension_job.rb
@@ -5,61 +5,63 @@ class ExtensionJob < ApplicationJob
   require 'uri'
 
   def perform(user_id, url, extension_id, item_ids = [], force_mute = false)
-    user = User.find_by_uuid(user_id)
+    distribute_reads do
+      user = User.find_by_uuid(user_id)
 
-    return if user.nil?
+      return if user.nil?
 
-    items = if item_ids.length.positive?
-      user.items.find(item_ids)
-    else
-      user.items.where(deleted: false).to_a
-    end
+      items = if item_ids.length.positive?
+        user.items.find(item_ids)
+      else
+        user.items.where(deleted: false).to_a
+      end
 
-    auth_params = user.key_params
+      auth_params = user.key_params
 
-    settings = ExtensionSetting.find_or_create_by(extension_id: extension_id)
-    mute_emails = force_mute || settings.mute_emails
+      settings = ExtensionSetting.find_or_create_by(extension_id: extension_id)
+      mute_emails = force_mute || settings.mute_emails
 
-    tmp_file = prepare_tmp_file(auth_params, items)
-    filename = upload_tmp_file_to_s3(tmp_file.path)
-    tmp_file.close
-    tmp_file.unlink
+      tmp_file = prepare_tmp_file(auth_params, items)
+      filename = upload_tmp_file_to_s3(tmp_file.path)
+      tmp_file.close
+      tmp_file.unlink
 
-    payload = {
-      items: items,
-      backup_filename: filename,
-      user_uuid: user.uuid,
-      auth_params: auth_params,
-      silent: mute_emails,
-      settings_id: settings.uuid,
-    }.to_json
+      payload = {
+        items: items,
+        backup_filename: filename,
+        user_uuid: user.uuid,
+        auth_params: auth_params,
+        silent: mute_emails,
+        settings_id: settings.uuid,
+      }.to_json
 
-    begin
-      uri = URI.parse(url)
-      http = Net::HTTP.new(uri.host, uri.port)
-      req = Net::HTTP::Post.new(uri.request_uri, 'Content-Type' => 'application/json')
-      req.body = payload
-      http.use_ssl = (uri.scheme == 'https')
-    rescue StandardError => e
-      Rails.logger.error "Error creating extensions server request: #{e.message}"
-      return
-    end
+      begin
+        uri = URI.parse(url)
+        http = Net::HTTP.new(uri.host, uri.port)
+        req = Net::HTTP::Post.new(uri.request_uri, 'Content-Type' => 'application/json')
+        req.body = payload
+        http.use_ssl = (uri.scheme == 'https')
+      rescue StandardError => e
+        Rails.logger.error "Error creating extensions server request: #{e.message}"
+        return
+      end
 
-    sent = false
-    begin
-      response = http.request(req)
-      sent = response.code.starts_with?('2')
-    rescue StandardError => e
-      Rails.logger.error "Failed to send a request to extensions server: #{e.message}"
-      Rails.logger.info "Response code was #{response.code}. Body sample: #{response.body[0, 100]}" if response
-    end
+      sent = false
+      begin
+        response = http.request(req)
+        sent = response.code.starts_with?('2')
+      rescue StandardError => e
+        Rails.logger.error "Failed to send a request to extensions server: #{e.message}"
+        Rails.logger.info "Response code was #{response.code}. Body sample: #{response.body[0, 100]}" if response
+      end
 
-    unless sent
-      UserMailer.failed_backup(
-        user_id,
-        extension_id,
-        settings.uuid
-      ).deliver_now unless mute_emails
+      unless sent
+        UserMailer.failed_backup(
+          user_id,
+          extension_id,
+          settings.uuid
+        ).deliver_now unless mute_emails
+      end
     end
   rescue StandardError => e
     Rails.logger.error "Could not perform extension job: #{e.message}"

--- a/config/database.yml
+++ b/config/database.yml
@@ -10,7 +10,6 @@
 #   http://dev.mysql.com/doc/refman/5.0/en/old-client.html
 #
 default: &default
-  adapter: mysql2
   encoding: utf8
   pool: <%= ENV['DB_POOL_SIZE'] %>
   wait_timeout: <%= ENV['DB_WAIT_TIMEOUT'] %>
@@ -20,6 +19,24 @@ default: &default
   host: <%= ENV['DB_HOST'] %>
   port: <%= ENV['DB_PORT'] %>
   reconnect: true
+  <% if ENV['DB_REPLICA_HOST'] %>
+  adapter: 'mysql2_makara'
+  makara:
+    id: mysql
+    blacklist_duration: 5
+    master_ttl: 5
+    master_strategy: round_robin
+    sticky: true
+    connections:
+      - role: master
+        host: <%= ENV['DB_HOST'] %>
+        name: primary
+      - role: slave
+        host: <%= ENV['DB_REPLICA_HOST'] %>
+        name: replica
+  <% else %>
+  adapter: mysql2
+  <% end %>
 
 development:
   <<: *default


### PR DESCRIPTION
This (along with infra changes) will allow the `SELECT ...` queries to be directed to the database read replica node instead of the primary node in order to reduce the heavy lifting on the primary db. 

For now (starting small) it only applies to 3 jobs: cleanup revisions job, extensions job and duplicate revisions job.