### PR TITLE
Refactor revisions cleanup

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -53,3 +53,6 @@ EMAIL_ATTACHMENT_MAX_SIZE=10485760
 
 # (Optional) Database Replication
 #DB_REPLICA_HOST=
+
+# Revisions Retention
+REVISIONS_RETENTION_DAYS=30

--- a/app/controllers/api/revisions_controller.rb
+++ b/app/controllers/api/revisions_controller.rb
@@ -22,8 +22,10 @@ class Api::RevisionsController < Api::ApiController
       return render json: { error: { message: 'Item not found' } }, status: :not_found
     end
 
+    revisions_retention_days = ENV['REVISIONS_RETENTION_DAYS'] ? ENV['REVISIONS_RETENTION_DAYS'].to_i : 30
+
     revisions = item.revisions
-      .where(created_at: User::REVISIONS_RETENTION_DAYS.days.ago..DateTime::Infinity.new)
+      .where(created_at: revisions_retention_days.days.ago..DateTime::Infinity.new)
       .select('revisions.uuid, content_type, created_at, updated_at')
       .order(created_at: :desc)
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -161,16 +161,14 @@ class Item < ApplicationRecord
         counter += 1
       end
 
-      Revision
+      revisions
         .using(:master)
-        .where(item_uuid: uuid)
         .where(creation_date: date)
         .where.not(uuid: revisions_to_keep)
         .delete_all
 
-      ItemRevision
+      item_revisions
         .using(:master)
-        .where(item_uuid: uuid)
         .where(revision_uuid: revisions_from_date.difference(revisions_to_keep))
         .delete_all
     end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -161,14 +161,16 @@ class Item < ApplicationRecord
         counter += 1
       end
 
-      revisions
+      Revision
         .using(:master)
+        .where(item_uuid: uuid)
         .where(creation_date: date)
         .where.not(uuid: revisions_to_keep)
         .delete_all
 
-      item_revisions
+      ItemRevision
         .using(:master)
+        .where(item_uuid: uuid)
         .where(revision_uuid: revisions_from_date.difference(revisions_to_keep))
         .delete_all
     end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,7 +3,7 @@ class Item < ApplicationRecord
   has_many :item_revisions, foreign_key: 'item_uuid', dependent: :destroy
   has_many :revisions, through: :item_revisions, dependent: :destroy
 
-  after_commit :persist_revision, :cleanup_excessive_revisions
+  after_commit :persist_revision
   after_create :duplicate_revisions
 
   def serializable_hash(options = {})
@@ -69,12 +69,6 @@ class Item < ApplicationRecord
   end
 
   private
-
-  def cleanup_excessive_revisions(days = User::REVISIONS_RETENTION_DAYS)
-    if content_type == 'Note'
-      CleanupRevisionsJob.perform_later(uuid, days)
-    end
-  end
 
   def duplicate_revisions
     if content_type == 'Note' && duplicate_of?

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,7 @@
 class Item < ApplicationRecord
+  MAX_REVISIONS_PER_DAY = 30
+  MIN_REVISIONS_PER_DAY = 2
+
   belongs_to :user, foreign_key: 'user_uuid', optional: true
   has_many :item_revisions, foreign_key: 'item_uuid', dependent: :destroy
   has_many :revisions, through: :item_revisions, dependent: :destroy
@@ -68,6 +71,25 @@ class Item < ApplicationRecord
     end
   end
 
+  def cleanup_revisions(days)
+    last_days_of_revisions = revisions
+      .select(:creation_date)
+      .order(creation_date: :desc)
+      .group(:creation_date)
+      .take(days)
+
+    days_to_process = []
+    last_days_of_revisions.each do |revision|
+      days_to_process.push(revision.creation_date)
+    end
+
+    days_to_process.each do |day|
+      days_from_today = (DateTime.now - day).to_i
+      allowed_revisions_count = [[days - days_from_today, MAX_REVISIONS_PER_DAY].min, MIN_REVISIONS_PER_DAY].max
+      cleanup_revisions_for_a_day(days_from_today, allowed_revisions_count)
+    end
+  end
+
   private
 
   def duplicate_revisions
@@ -92,6 +114,65 @@ class Item < ApplicationRecord
       item_revision.item_uuid = uuid
       item_revision.revision_uuid = revision.uuid
       item_revision.save
+    end
+  end
+
+  def cleanup_revisions_for_a_day(days_from_today, allowed_revisions_count)
+    date = Time.now.utc.to_date - days_from_today
+    revisions_from_date_count = revisions.where(creation_date: date).count
+
+    if revisions_from_date_count > allowed_revisions_count
+      revisions_from_date = revisions
+        .select(:uuid)
+        .where(creation_date: date)
+        .order(creation_date: :desc)
+        .pluck(:uuid)
+
+      revisions_slice_size = (revisions_from_date.length.to_f / allowed_revisions_count).floor
+      revisions_divided_into_slices = revisions_from_date.each_slice(revisions_slice_size).to_a
+      first_slice = revisions_divided_into_slices.shift
+      last_slice = revisions_divided_into_slices.pop
+
+      revisions_to_keep = [
+        first_slice.first,
+        last_slice.last,
+      ]
+
+      beginning_counter = 0
+      end_counter = revisions_divided_into_slices.length - 1
+      counter = 0
+      while revisions_to_keep.length < allowed_revisions_count
+        if counter.odd?
+          revisions_to_keep.push(
+            revisions_divided_into_slices[beginning_counter][
+              (revisions_divided_into_slices[beginning_counter].length.to_f / 2).floor
+            ]
+          )
+          beginning_counter += 1
+        else
+          revisions_to_keep.push(
+            revisions_divided_into_slices[end_counter][
+              (revisions_divided_into_slices[end_counter].length.to_f / 2).floor
+            ]
+          )
+          end_counter -= 1
+        end
+
+        counter += 1
+      end
+
+      Revision
+        .using(:master)
+        .where(item_uuid: uuid)
+        .where(creation_date: date)
+        .where.not(uuid: revisions_to_keep)
+        .delete_all
+
+      ItemRevision
+        .using(:master)
+        .where(item_uuid: uuid)
+        .where(revision_uuid: revisions_from_date.difference(revisions_to_keep))
+        .delete_all
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,8 +12,6 @@ class User < ApplicationRecord
 
   SESSIONS_PROTOCOL_VERSION = 4
 
-  REVISIONS_RETENTION_DAYS = 30
-
   def serializable_hash(options = {})
     super(options.merge(only: ['email', 'uuid']))
   end

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -39,6 +39,11 @@ case "$COMMAND" in
     bundle exec rake "items:perform_daily_backup_jobs[false]"
     ;;
 
+  'cleanup-revisions' )
+    echo "Starting Revisions Cleanup..."
+    bundle exec rake "items:cleanup_revisions"
+    ;;
+
   * )
     echo "Unknown command"
     ;;

--- a/lib/tasks/cleanup_revisions.rake
+++ b/lib/tasks/cleanup_revisions.rake
@@ -7,12 +7,14 @@ namespace :items do
   MIN_REVISIONS_PER_DAY = 2
 
   task cleanup_revisions: :environment do
+    revisions_retention_days = ENV['REVISIONS_RETENTION_DAYS'] ? ENV['REVISIONS_RETENTION_DAYS'].to_i : 30
+
     Octopus.using(:slave1) do
       Item.where('updated.at >= ?', Date.today.beginning_of_day).find_in_batches.with_index do |group, batch|
         Rails.logger.info "Cleaning up revisions for items. Batch ##{batch}"
 
         group.each do |item|
-          cleanup_item_revisions(item, days)
+          cleanup_item_revisions(item, revisions_retention_days)
         end
       end
     end

--- a/lib/tasks/cleanup_revisions.rake
+++ b/lib/tasks/cleanup_revisions.rake
@@ -3,98 +3,17 @@
 namespace :items do
   desc 'Cleanup revisions'
 
-  MAX_REVISIONS_PER_DAY = 30
-  MIN_REVISIONS_PER_DAY = 2
-
   task cleanup_revisions: :environment do
     revisions_retention_days = ENV['REVISIONS_RETENTION_DAYS'] ? ENV['REVISIONS_RETENTION_DAYS'].to_i : 30
 
     Octopus.using(:slave1) do
-      Item.where('updated.at >= ?', Date.today.beginning_of_day).find_in_batches.with_index do |group, batch|
+      Item.where('updated_at >= ?', 1.hour.ago).find_in_batches.with_index do |group, batch|
         Rails.logger.info "Cleaning up revisions for items. Batch ##{batch}"
 
         group.each do |item|
-          cleanup_item_revisions(item, revisions_retention_days)
+          item.cleanup_revisions(revisions_retention_days)
         end
       end
-    end
-  end
-
-  def cleanup_item_revisions(item, days)
-    last_days_of_revisions = item.revisions
-      .select(:creation_date)
-      .order(creation_date: :desc)
-      .group(:creation_date)
-      .take(days)
-
-    days_to_process = []
-    last_days_of_revisions.each do |revision|
-      days_to_process.push(revision.creation_date)
-    end
-
-    days_to_process.each do |day|
-      days_from_today = (DateTime.now - day).to_i
-      allowed_revisions_count = [[days - days_from_today, MAX_REVISIONS_PER_DAY].min, MIN_REVISIONS_PER_DAY].max
-      cleanup_revisions_for_a_day(item, days_from_today, allowed_revisions_count)
-    end
-  end
-
-  def cleanup_revisions_for_a_day(item, days_from_today, allowed_revisions_count)
-    date = Time.now.utc.to_date - days_from_today
-    revisions_from_date_count = item.revisions.where(creation_date: date).count
-
-    if revisions_from_date_count > allowed_revisions_count
-      revisions_from_date = item.revisions
-        .select(:uuid)
-        .where(creation_date: date)
-        .order(creation_date: :desc)
-        .pluck(:uuid)
-
-      revisions_slice_size = (revisions_from_date.length.to_f / allowed_revisions_count).floor
-      revisions_divided_into_slices = revisions_from_date.each_slice(revisions_slice_size).to_a
-      first_slice = revisions_divided_into_slices.shift
-      last_slice = revisions_divided_into_slices.pop
-
-      revisions_to_keep = [
-        first_slice.first,
-        last_slice.last,
-      ]
-
-      beginning_counter = 0
-      end_counter = revisions_divided_into_slices.length - 1
-      counter = 0
-      while revisions_to_keep.length < allowed_revisions_count
-        if counter.odd?
-          revisions_to_keep.push(
-            revisions_divided_into_slices[beginning_counter][
-              (revisions_divided_into_slices[beginning_counter].length.to_f / 2).floor
-            ]
-          )
-          beginning_counter += 1
-        else
-          revisions_to_keep.push(
-            revisions_divided_into_slices[end_counter][
-              (revisions_divided_into_slices[end_counter].length.to_f / 2).floor
-            ]
-          )
-          end_counter -= 1
-        end
-
-        counter += 1
-      end
-
-      Revision
-        .using(:master)
-        .where(item_uuid: item.uuid)
-        .where(creation_date: date)
-        .where.not(uuid: revisions_to_keep)
-        .delete_all
-
-      ItemRevision
-        .using(:master)
-        .where(item_uuid: item.uuid)
-        .where(revision_uuid: revisions_from_date.difference(revisions_to_keep))
-        .delete_all
     end
   end
 end

--- a/lib/tasks/cleanup_revisions.rake
+++ b/lib/tasks/cleanup_revisions.rake
@@ -1,38 +1,40 @@
-class CleanupRevisionsJob < ApplicationJob
-  queue_as ENV['SQS_QUEUE_LOW_PRIORITY'] || 'sn_main_low_priority'
+# frozen_string_literal: true
+
+namespace :items do
+  desc 'Cleanup revisions'
 
   MAX_REVISIONS_PER_DAY = 30
   MIN_REVISIONS_PER_DAY = 2
 
-  def perform(item_id, days)
+  task cleanup_revisions: :environment do
     Octopus.using(:slave1) do
-      item = Item.find_by_uuid(item_id)
+      Item.where('updated.at >= ?', Date.today.beginning_of_day).find_in_batches.with_index do |group, batch|
+        Rails.logger.info "Cleaning up revisions for items. Batch ##{batch}"
 
-      unless item
-        Rails.logger.warn "Could not find item with uuid #{item_id}"
-
-        return
-      end
-
-      last_days_of_revisions = item.revisions
-        .select(:creation_date)
-        .order(creation_date: :desc)
-        .group(:creation_date)
-        .take(days)
-
-      days_to_process = []
-      last_days_of_revisions.each do |revision|
-        days_to_process.push(revision.creation_date)
-      end
-
-      days_to_process.each do |day|
-        days_from_today = (DateTime.now - day).to_i
-        allowed_revisions_count = [[days - days_from_today, MAX_REVISIONS_PER_DAY].min, MIN_REVISIONS_PER_DAY].max
-        cleanup_revisions_for_a_day(item, days_from_today, allowed_revisions_count)
+        group.each do |item|
+          cleanup_item_revisions(item, days)
+        end
       end
     end
-  rescue StandardError => e
-    Rails.logger.error "Could not cleanup revisions for item #{item_id}: #{e.message}"
+  end
+
+  def cleanup_item_revisions(item, days)
+    last_days_of_revisions = item.revisions
+      .select(:creation_date)
+      .order(creation_date: :desc)
+      .group(:creation_date)
+      .take(days)
+
+    days_to_process = []
+    last_days_of_revisions.each do |revision|
+      days_to_process.push(revision.creation_date)
+    end
+
+    days_to_process.each do |day|
+      days_from_today = (DateTime.now - day).to_i
+      allowed_revisions_count = [[days - days_from_today, MAX_REVISIONS_PER_DAY].min, MIN_REVISIONS_PER_DAY].max
+      cleanup_revisions_for_a_day(item, days_from_today, allowed_revisions_count)
+    end
   end
 
   def cleanup_revisions_for_a_day(item, days_from_today, allowed_revisions_count)

--- a/spec/tasks/cleanup_revisions.rb
+++ b/spec/tasks/cleanup_revisions.rb
@@ -1,10 +1,8 @@
 require 'rails_helper'
 
-RSpec.describe CleanupRevisionsJob do
-  subject do
-    described_class.new
-  end
+Rails.application.load_tasks
 
+RSpec.describe 'items:cleanup_revisions' do
   let(:test_user) do
     create(:user, password: '123456')
   end
@@ -40,7 +38,7 @@ RSpec.describe CleanupRevisionsJob do
     end
 
     it 'should clean up revisions from last 30 days' do
-      subject.perform(test_item.uuid, 30)
+      run_task(task_name: 'items:cleanup_revisions')
 
       revisions = test_item.revisions.where(creation_date: 29.days.ago..Date::Infinity.new)
       expect(revisions.length).to eq(466)
@@ -48,7 +46,7 @@ RSpec.describe CleanupRevisionsJob do
     end
 
     it 'should clean up revisions in a decaying fashion for last 30 days' do
-      subject.perform(test_item.uuid, 30)
+      run_task(task_name: 'items:cleanup_revisions')
 
       revisions = test_item
         .revisions
@@ -100,14 +98,14 @@ RSpec.describe CleanupRevisionsJob do
     end
 
     it 'should clean up revisions from last 30 days' do
-      subject.perform(test_item.uuid, 30)
+      run_task(task_name: 'items:cleanup_revisions')
 
       revisions = test_item.revisions.where(creation_date: 29.days.ago..Date::Infinity.new)
       expect(revisions.length).to eq(50)
     end
 
     it 'should clean up revisions in a decaying fashion for last 30 days' do
-      subject.perform(test_item.uuid, 30)
+      run_task(task_name: 'items:cleanup_revisions')
 
       revisions = test_item.revisions.where(creation_date: 29.days.ago..Date::Infinity.new)
 
@@ -134,4 +132,14 @@ RSpec.describe CleanupRevisionsJob do
       end
     end
   end
+end
+
+def run_task(task_name:)
+  stdout = StringIO.new
+  $stdout = stdout
+  Rake::Task[task_name].invoke
+  $stdout = STDOUT
+  Rake.application[task_name].reenable
+
+  stdout.string
 end


### PR DESCRIPTION
The idea is to run the `revisions_cleanup` rake task on every let's say 30 minutes and it will pick up items updated during last hour and clean their revisions. I'm open for suggestions in terms of adjusting these params.

