### PR TITLE
fix: deleting accounts with large number of items

### DIFF
--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -12,10 +12,12 @@ class Admin::AdminController < ApplicationController
   def delete_account
     email = params[:email]
     user = User.find_by_email email
-    if user
-      user.items.destroy_all
-      user.delete
-    end
+
+    return render json: { error: { message: 'User not found' } }, status: :not_found unless user
+
+    user.delete
+
+    AccountCleanupJob.perform_later(user.uuid)
 
     render json: {}, status: 200
   end

--- a/app/jobs/account_cleanup_job.rb
+++ b/app/jobs/account_cleanup_job.rb
@@ -1,0 +1,15 @@
+class AccountCleanupJob < ApplicationJob
+  def perform(user_id)
+    Rails.logger.info "Performing account cleanup job for user: #{user_id}"
+
+    Item.using(:slave1).where(user_uuid: user_id).find_each do |item|
+      Octopus.using(:master) do
+        Revision.where(item_uuid: item.uuid).delete_all
+        ItemRevision.where(item_uuid: item.uuid).delete_all
+        item.delete
+      end
+    end
+
+    Rails.logger.info "Finished account cleanup job for user: #{user_id}"
+  end
+end

--- a/spec/controllers/admin/admin_controller_spec.rb
+++ b/spec/controllers/admin/admin_controller_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe Admin::AdminController, type: :controller do
 
     it 'should throw unauthorized if not admin_key is not valid' do
       post :delete_account, params: { admin_key: 'something_else' }
+
+      expect(AccountCleanupJob).to_not have_been_enqueued
+
       expect(response).to have_http_status(:unauthorized)
       expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
       expect(JSON.parse(response.body)).to eq({})
@@ -23,6 +26,9 @@ RSpec.describe Admin::AdminController, type: :controller do
       test_registration = user_manager.register('test@testing.com', '123456', params)
 
       post :delete_account, params: { email: test_registration[:user][:email], admin_key: ENV['ADMIN_KEY'] }
+
+      expect(AccountCleanupJob).to have_been_enqueued
+
       expect(response).to have_http_status(:ok)
       expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
       expect(JSON.parse(response.body)).to eq({})

--- a/spec/jobs/account_cleanup_job.rb
+++ b/spec/jobs/account_cleanup_job.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe AccountCleanupJob do
+  subject do
+    described_class.new
+  end
+
+  let(:test_user) do
+    create(:user, password: '123456')
+  end
+
+  let(:original_item) do
+    create(:item, :note_type, user_uuid: test_user.uuid, content: 'This is a test note.')
+  end
+
+  let(:amount_of_revisions_to_generate) do
+    40
+  end
+
+  before(:each) do
+    amount_of_revisions_to_generate.times do
+      revision = Revision.new
+      revision.auth_hash = original_item.auth_hash
+      revision.content = (0...8).map { (65 + rand(26)).chr }.join
+      revision.content_type = original_item.content_type
+      revision.creation_date = Date.today
+      revision.enc_item_key = original_item.enc_item_key
+      revision.item_uuid = original_item.uuid
+      revision.items_key_id = original_item.items_key_id
+      revision.save
+
+      item_revision = ItemRevision.new
+      item_revision.item_uuid = original_item.uuid
+      item_revision.revision_uuid = revision.uuid
+      item_revision.save
+    end
+  end
+
+  it 'should remove all items and their revisions for an account' do
+    subject.perform(test_user.uuid)
+
+    items = Item.all
+
+    expect(items.length).to eq(0)
+
+    revisions = Revision.all
+
+    expect(revisions.length).to eq(0)
+
+    item_revisions = ItemRevision.all
+
+    expect(item_revisions.length).to eq(0)
+  end
+end


### PR DESCRIPTION
When an account has a lot of items (for example we had a test account that had 8k items) the process of deleting account with all it's items and revisions takes too long to be completed withing a single request - thus a user cannot reset his account. 

Delegated the items/revisions cleanup to an async job that is done after the user deletes the account.