### PR TITLE
fix: more precise sync date conflict handling

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -20,7 +20,10 @@ class Item < ApplicationRecord
       'updated_at',
     ]
 
-    super(options.merge(only: allowed_options))
+    super(options.merge(only: allowed_options)).merge({
+      "created_at" => created_at&.iso8601(6),
+      "updated_at" => updated_at&.iso8601(6),
+    })
   end
 
   def decoded_content

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -96,7 +96,9 @@ class User < ApplicationRecord
   end
 
   def compute_data_signature
-    # in my testing, .select performs better than .pluck
+    # In local benchmarks, .select performs better than .pluck
+    # JS clients only support millisecond precision, so we format to that precision
+    # and not microsecond precision.
     dates = items.where(deleted: false).where.not(content_type: nil)
       .select(:updated_at).map { |item| item.updated_at.to_datetime.strftime('%Q') }
 

--- a/lib/sync_engine/2016_12_15/sync_manager.rb
+++ b/lib/sync_engine/2016_12_15/sync_manager.rb
@@ -17,7 +17,7 @@ module SyncEngine
         check_for_conflicts(saved_items, retrieved_items, unsaved_items)
 
         # add 1 microsecond to avoid returning same object in subsequent sync
-        last_updated = (last_updated.to_time + 1 / 100000.0).to_datetime.utc
+        last_updated = (last_updated.to_time + 1 / 1_000_000.0).to_datetime.utc
 
         sync_token = sync_token_from_datetime(last_updated)
         {

--- a/lib/sync_engine/2019_05_20/sync_manager.rb
+++ b/lib/sync_engine/2019_05_20/sync_manager.rb
@@ -16,7 +16,7 @@ module SyncEngine
         end
 
         # add 1 microsecond to avoid returning same object in subsequent sync
-        last_updated = (last_updated.to_time + 1 / 100000.0).to_datetime.utc
+        last_updated = (last_updated.to_time + 1 / 1_000_000.0).to_datetime.utc
         sync_token = sync_token_from_datetime(last_updated)
 
         {
@@ -28,9 +28,12 @@ module SyncEngine
         }
       end
 
-      # Ignore differences that are at most this many seconds apart
-      # Anything over this threshold will be conflicted.
-      MIN_CONFLICT_INTERVAL = 1.0
+      # Do not create conflicts for differences that are MIN_CONFLICT_INTERVAL_MICROSECONDS apart,
+      # instead just saving directly and overwriting server value.
+      # JavaScript only supports timestamps in milliseconds (3 decimal places), whereas we save timestamps
+      # in microseconds (6 decimal places). Any changes made <= 1 millisecond apart will not be treated as a conflict.
+      MIN_CONFLICT_INTERVAL_MICROSECONDS = 1_000
+      MICROSECONDS_IN_SEC = 1_000_000
 
       def _sync_save(item_hashes, request, retrieved_items)
         unless item_hashes
@@ -53,25 +56,19 @@ module SyncEngine
           end
 
           if item
-            # We want to check if this updated_at value is equal to the item's current updated_at value.
-            # If they differ, it means the client is attempting to save an item which hasn't been updated.
-            # In this case, if the incoming_item.updated_at < server_item.updated_at, always conflict.
-            # We don't want old items overriding newer ones.
-            # incoming_item.updated_at > server_item.updated_at would seem to be impossible,
-            # as only servers are responsible for setting updated_at.
-            # But assuming a rogue client has gotten away with it,
-            # we should also conflict in this case if the difference between the dates is greater
-            # than MIN_CONFLICT_INTERVAL seconds.
+            # We want to check if the incoming updated_at value is equal to the item's current updated_at value.
+            # If they differ, it means the client is attempting to save an item which doesn't have the correct server value.
+            # We conflict if the difference in dates is greater than the 1 unit of precision (MIN_CONFLICT_INTERVAL_MICROSECONDS)
 
             our_updated_at = item.updated_at
-            difference = incoming_updated_at.to_f - our_updated_at.to_f
+            difference_microseconds = (incoming_updated_at.to_f - our_updated_at.to_f) * MICROSECONDS_IN_SEC
 
-            save_incoming = if difference < 0
+            save_incoming = if difference_microseconds < 0
               # incoming is less than ours. This implies stale data. Don't save if greater than interval
-              difference.abs < MIN_CONFLICT_INTERVAL
-            elsif difference > 0
+              difference_microseconds.abs < MIN_CONFLICT_INTERVAL_MICROSECONDS
+            elsif difference_microseconds > 0
               # incoming is greater than ours. Should never be the case. If so though, don't save.
-              difference.abs < MIN_CONFLICT_INTERVAL
+              difference_microseconds.abs < MIN_CONFLICT_INTERVAL_MICROSECONDS
             else
               # incoming is equal to ours (which is desired, healthy behavior), continue with saving.
               true

--- a/lib/sync_engine/2020_01_15/sync_manager.rb
+++ b/lib/sync_engine/2020_01_15/sync_manager.rb
@@ -25,7 +25,7 @@ module SyncEngine
         end
 
         # add 1 microsecond to avoid returning same object in subsequent sync
-        last_updated = (last_updated.to_time + 1 / 100000.0).to_datetime.utc
+        last_updated = (last_updated.to_time + (1 / 1_000_000.0)).to_datetime.utc
         sync_token = sync_token_from_datetime(last_updated)
 
         {

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -82,9 +82,7 @@ RSpec.describe Api::ItemsController, type: :controller do
             expect(retrieved_items.count).to be_equal(note_items.count)
 
             retrieved_items = serialize_to_hash(retrieved_items)
-            note_items = note_items.to_a.map(&:serializable_hash)
-
-            note_items = serialize_to_hash(note_items)
+            note_items = serialize_to_hash(note_items.to_a.map(&:serializable_hash))
             expect(retrieved_items).to match_array(note_items)
           end
         end
@@ -101,6 +99,7 @@ RSpec.describe Api::ItemsController, type: :controller do
             items_param = test_items.limit(5).to_a.map(&:serializable_hash)
             items_param[0]['content'] = 'This is the new content.'
             items_param[1]['content'] = 'And this too.'
+            items_param = items_param.as_json
 
             post :sync, params: { sync_token: '', cursor_token: '', limit: 5, api: '20190520', items: items_param }
 
@@ -120,7 +119,6 @@ RSpec.describe Api::ItemsController, type: :controller do
             expect(saved_items.count).to be_equal(items_param.count)
 
             saved_items = serialize_to_hash(saved_items)
-
             items_param = serialize_to_hash(items_param)
             expect(saved_items).to match_array(items_param)
           end
@@ -137,6 +135,7 @@ RSpec.describe Api::ItemsController, type: :controller do
             # Serializing the items into an array of hashes
             items_param = test_items.limit(3).to_a.map(&:serializable_hash)
             items_param[0]['deleted'] = true
+            items_param = items_param.as_json
 
             post :sync, params: { limit: 5, api: '20190520', items: items_param }
 
@@ -192,6 +191,7 @@ RSpec.describe Api::ItemsController, type: :controller do
 
             new_item = [new_item].to_a.map(&:serializable_hash)[0]
             items_param.push(new_item)
+            items_param = items_param.as_json
 
             sync_token = Base64.encode64('2:' + DateTime.now.to_f.to_s)
             post :sync, params: { sync_token: sync_token, limit: 5, api: '20190520', items: items_param }
@@ -239,6 +239,7 @@ RSpec.describe Api::ItemsController, type: :controller do
 
             items_param = [new_item].to_a.map(&:serializable_hash)
             items_param[0].delete('items_key_id')
+            items_param = items_param.as_json
 
             post :sync, params: { limit: 5, api: '20190520', items: items_param }
 
@@ -265,6 +266,7 @@ RSpec.describe Api::ItemsController, type: :controller do
 
             items_param = [new_item].to_a.map(&:serializable_hash)
             items_param[0].delete('auth_hash')
+            items_param = items_param.as_json
 
             post :sync, params: { limit: 5, api: '20190520', items: items_param }
 
@@ -337,6 +339,7 @@ RSpec.describe Api::ItemsController, type: :controller do
             items_param = test_items.limit(5).to_a.map(&:serializable_hash)
             items_param[0]['content'] = 'This is the new content.'
             items_param[1]['content'] = 'And this too.'
+            items_param = items_param.as_json
 
             post :sync, params: { sync_token: '', cursor_token: '', limit: 5, api: '20190520', items: items_param }
 
@@ -378,6 +381,7 @@ RSpec.describe Api::ItemsController, type: :controller do
             # Serializing the items into an array of hashes
             items_param = test_items.limit(3).to_a.map(&:serializable_hash)
             items_param[0]['deleted'] = true
+            items_param = items_param.as_json
 
             post :sync, params: { limit: 5, api: '20190520', items: items_param }
 
@@ -438,6 +442,7 @@ RSpec.describe Api::ItemsController, type: :controller do
 
             new_item = [new_item].to_a.map(&:serializable_hash)[0]
             items_param.push(new_item)
+            items_param = items_param.as_json
 
             sync_token = Base64.encode64('2:' + DateTime.now.to_f.to_s)
             post :sync, params: { sync_token: sync_token, limit: 5, api: '20190520', items: items_param }
@@ -490,6 +495,7 @@ RSpec.describe Api::ItemsController, type: :controller do
 
             items_param = [new_item].to_a.map(&:serializable_hash)
             items_param[0].delete('items_key_id')
+            items_param = items_param.as_json
 
             post :sync, params: { limit: 5, api: '20190520', items: items_param }
 
@@ -521,6 +527,7 @@ RSpec.describe Api::ItemsController, type: :controller do
 
             items_param = [new_item].to_a.map(&:serializable_hash)
             items_param[0].delete('auth_hash')
+            items_param = items_param.as_json
 
             post :sync, params: { limit: 5, api: '20190520', items: items_param }
 
@@ -549,6 +556,7 @@ RSpec.describe Api::ItemsController, type: :controller do
 
             items_param = [new_item].to_a.map(&:serializable_hash)
             items_param[0].delete('items_key_id')
+            items_param = items_param.as_json
 
             post :sync, params: { limit: 5, api: '20200115', items: items_param }
 
@@ -575,6 +583,7 @@ RSpec.describe Api::ItemsController, type: :controller do
 
             items_param = [new_item].to_a.map(&:serializable_hash)
             items_param[0].delete('auth_hash')
+            items_param = items_param.as_json
 
             post :sync, params: { limit: 5, api: '20200115', items: items_param }
 
@@ -608,6 +617,7 @@ RSpec.describe Api::ItemsController, type: :controller do
 
             items_param = [new_item].to_a.map(&:serializable_hash)
             items_param[0].delete('items_key_id')
+            items_param = items_param.as_json
 
             post :sync, params: { limit: 5, api: '20200115', items: items_param }
 
@@ -643,6 +653,7 @@ RSpec.describe Api::ItemsController, type: :controller do
 
             items_param = [new_item].to_a.map(&:serializable_hash)
             items_param[0].delete('items_key_id')
+            items_param = items_param.as_json
 
             post :sync, params: { limit: 5, api: '20200115', items: items_param }
 
@@ -674,6 +685,7 @@ RSpec.describe Api::ItemsController, type: :controller do
 
             items_param = [new_item].to_a.map(&:serializable_hash)
             items_param[0].delete('auth_hash')
+            items_param = items_param.as_json
 
             post :sync, params: { limit: 5, api: '20200115', items: items_param }
 
@@ -716,6 +728,7 @@ RSpec.describe Api::ItemsController, type: :controller do
 
             items_param = [new_item].to_a.map(&:serializable_hash)
             items_param[0].delete('items_key_id')
+            items_param = items_param.as_json
 
             post :sync, params: { limit: 5, api: '20200115', items: items_param }
 
@@ -768,6 +781,7 @@ RSpec.describe Api::ItemsController, type: :controller do
 
             items_param = [new_item].to_a.map(&:serializable_hash)
             items_param[0].delete('items_key_id')
+            items_param = items_param.as_json
 
             post :sync, params: { limit: 5, items: items_param }
 
@@ -794,6 +808,7 @@ RSpec.describe Api::ItemsController, type: :controller do
 
             items_param = [new_item].to_a.map(&:serializable_hash)
             items_param[0].delete('auth_hash')
+            items_param = items_param.as_json
 
             post :sync, params: { limit: 5, items: items_param }
 


### PR DESCRIPTION
Prior to this change, the server was somewhat liberal with did not constitute a conflict. Any changes that were within 1 second apart would not conflict. This means naturally that if there are indeed different contents, but somehow performed within 500ms apart, a stale copy could overwrite the server value.

This version reduces this threshold to the microsecond scale. Instead of a liberal interval of 1s, we instead allow only a maximum of 1000 microseconds (1 millisecond). Any changes greater than 1ms apart are automatically conflicted. This is a much stricter conflicting strategy, so could theoretically result in greater conflicts created, if the clients are not precisely tracking server dates. But this should not be the case.